### PR TITLE
Scaffold monorepo + canonical action schema (closes #5, #8)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default reviewer for every PR.
+*                       @knhn1004
+
+# Per-area ownership. Add teammates' GitHub handles as they pick up areas.
+/go-key-service/        @knhn1004
+/sdk-python/            @knhn1004
+/dashboard/             @knhn1004
+/contracts/             @knhn1004
+/docs/                  @knhn1004
+/.github/               @knhn1004

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- 1-3 bullets: what changed and why. Link the issue (e.g. Closes #8). -->
+
+## Acceptance checklist
+
+<!-- Copy the acceptance bullets from the linked issue and tick them. -->
+
+- [ ]
+- [ ]
+
+## Test plan
+
+- [ ] `go test ./...` (in `go-key-service/`)
+- [ ] `pytest -q` (in `sdk-python/`)
+- [ ] Other (describe):
+
+## Notes for reviewers
+
+<!-- Anything non-obvious: design tradeoffs, follow-ups, known limitations. -->

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,38 @@
+name: contracts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "contracts/**"
+      - ".github/workflows/contracts.yml"
+  pull_request:
+    paths:
+      - "contracts/**"
+      - ".github/workflows/contracts.yml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: contracts
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: skip if not scaffolded
+        id: gate
+        run: |
+          if [ ! -f foundry.toml ]; then
+            echo "foundry project not initialised yet — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: foundry-rs/foundry-toolchain@v1
+        if: steps.gate.outputs.skip != 'true'
+      - name: build
+        if: steps.gate.outputs.skip != 'true'
+        run: forge build --sizes
+      - name: test
+        if: steps.gate.outputs.skip != 'true'
+        run: forge test -vvv

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,42 @@
+name: dashboard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "dashboard/**"
+      - ".github/workflows/dashboard.yml"
+  pull_request:
+    paths:
+      - "dashboard/**"
+      - ".github/workflows/dashboard.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - name: skip if not scaffolded
+        id: gate
+        run: |
+          if [ ! -f package.json ]; then
+            echo "no package.json yet — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: install
+        if: steps.gate.outputs.skip != 'true'
+        run: npm ci
+      - name: lint
+        if: steps.gate.outputs.skip != 'true'
+        run: npm run lint --if-present
+      - name: build
+        if: steps.gate.outputs.skip != 'true'
+        run: npm run build

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -19,18 +19,19 @@ jobs:
         working-directory: dashboard
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: npm
-          cache-dependency-path: dashboard/package-lock.json
-      - name: skip if not scaffolded
+      - name: gate (skip until scaffolded)
         id: gate
         run: |
           if [ ! -f package.json ]; then
             echo "no package.json yet — skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
+      - uses: actions/setup-node@v4
+        if: steps.gate.outputs.skip != 'true'
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
       - name: install
         if: steps.gate.outputs.skip != 'true'
         run: npm ci

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,33 @@
+name: go
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go-key-service
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: false
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::gofmt diff in:" $unformatted
+            gofmt -d .
+            exit 1
+          fi
+      - name: vet
+        run: go vet ./...
+      - name: build
+        run: go build ./...
+      - name: test
+        run: go test ./...

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,27 @@
+name: python
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk-python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: install
+        run: pip install -e ".[dev]"
+      - name: lint
+        run: ruff check .
+      - name: format-check
+        run: ruff format --check .
+      - name: test
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,32 @@
+# OS
 .DS_Store
+
+# Editors
+.vscode/
+.idea/
+
+# Go
+go-key-service/bin/
+*.test
+*.out
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+.pytest_cache/
+.ruff_cache/
+*.egg-info/
+build/
+dist/
+
+# Node / dashboard
+node_modules/
+dashboard/dist/
+dashboard/.vite/
+
+# Foundry / contracts
+contracts/cache/
+contracts/out/
+contracts/lib/
+contracts/broadcast/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+        files: ^go-key-service/.*\.go$
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^sdk-python/.*\.py$
+      - id: ruff-format
+        files: ^sdk-python/.*\.py$
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        files: ^(dashboard|contracts|docs|\.github)/.*\.(ts|tsx|js|jsx|json|md|yml|yaml|sol)$

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# CryptoAgent
+
+Cryptographic guardrails for multi-agent AI systems. CS 168 (Spring 2026) project.
+
+## Layout
+
+| Path               | Purpose                                                              |
+|--------------------|----------------------------------------------------------------------|
+| `go-key-service/`  | Go HTTP service: Ed25519 keypairs, signing/verification primitives.  |
+| `sdk-python/`      | Python SDK + LangChain decorators consumed by agent code.            |
+| `dashboard/`       | React + TypeScript dashboard (Merkle tree + agent interaction view). |
+| `contracts/`       | Solidity anchoring contract (Foundry) for periodic root commits.     |
+| `docs/`            | Specs — start with [`docs/schema.md`](docs/schema.md).               |
+
+## Phases
+
+1. Core crypto infra (key service, signing, schema) — epic #1
+2. Merkle audit log + on-chain anchoring — epic #2
+3. Multi-sig consensus, ACL, Python SDK — epic #3
+4. Dashboard + demo — epic #4
+
+## Local checks
+
+```sh
+# Go
+( cd go-key-service && go test ./... )
+
+# Python
+( cd sdk-python && pip install -e ".[dev]" && pytest -q && ruff check . )
+
+# Pre-commit (one-time install)
+pip install pre-commit && pre-commit install
+```
+
+CI mirrors these on every PR (see `.github/workflows/`).

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,21 @@
+# contracts
+
+Solidity anchoring contract that periodically commits Merkle roots from the
+audit log to an Ethereum testnet. Tooling: Foundry.
+
+## Setup
+
+```sh
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+forge init --no-git --no-commit .
+```
+
+(Re-runs of `forge init` in this directory are no-ops once `foundry.toml` exists.)
+
+## Build / test
+
+```sh
+forge build
+forge test
+```

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,18 @@
+# dashboard
+
+React + TypeScript dashboard visualising the Merkle audit tree and live
+agent interactions. Scaffolded with Vite.
+
+## Setup
+
+```sh
+npm create vite@latest . -- --template react-ts
+npm install
+```
+
+## Dev / build
+
+```sh
+npm run dev
+npm run build
+```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,62 @@
+# Agent Action Schema (v1)
+
+Canonical signed message format used by every CryptoAgent component (Go key-service, Python SDK, dashboard, on-chain anchor). Defined once here; both runtime libraries (`go-key-service/internal/action` and `sdk-python/cryptoagent/action.py`) MUST produce byte-identical canonical encodings for equal inputs.
+
+## Action
+
+```jsonc
+{
+  "schema_version": 1,
+  "agent_id":       "<string>",   // stable opaque id, e.g. ULID
+  "action_type":    "<string>",   // snake_case verb, e.g. "transfer_funds"
+  "target":         "<string>",   // opaque resource id, application-defined
+  "timestamp":      <int64>,      // unix milliseconds, UTC
+  "nonce":          "<string>"    // 32-char lowercase hex (16 random bytes)
+}
+```
+
+All six fields are **required**. Unknown fields are rejected.
+
+## Canonical encoding
+
+JSON, with these rules (subset of RFC 8785 sufficient for our schema):
+
+1. UTF-8, no BOM.
+2. Object keys sorted ascending by Unicode code point.
+3. No insignificant whitespace (no spaces, no newlines).
+4. Strings: minimal JSON escaping (`"`, `\`, control chars `\u00xx`).
+5. Integers serialized without decimal point or exponent.
+
+The canonical bytes are what gets signed (`sign(canonical(action))`) and what gets hashed before Merkle append (`hash(canonical(action) || signature)`).
+
+Reference vector (must round-trip identically in Go and Python):
+
+```
+input:
+  schema_version=1
+  agent_id="agent-001"
+  action_type="ping"
+  target="peer-002"
+  timestamp=1700000000000
+  nonce="0123456789abcdef0123456789abcdef"
+
+canonical bytes:
+  {"action_type":"ping","agent_id":"agent-001","nonce":"0123456789abcdef0123456789abcdef","schema_version":1,"target":"peer-002","timestamp":1700000000000}
+```
+
+## Replay protection
+
+A verifier MUST reject an action if any of the following hold:
+
+| Check          | Rule                                                                 |
+|----------------|----------------------------------------------------------------------|
+| Schema version | `schema_version != 1`                                                |
+| Timestamp skew | `abs(server_now_ms - timestamp) > 30_000` (±30 s)                    |
+| Nonce window   | `(agent_id, nonce)` already seen within the last `600_000` ms (10 m) |
+| Nonce shape    | `nonce` is not exactly 32 lowercase hex chars                        |
+
+Verifiers SHOULD persist seen `(agent_id, nonce)` for at least `window = skew + nonce_window = 30 s + 600 s = 630 s` to close the boundary case.
+
+## Versioning
+
+Bump `SchemaVersion` (Go) / `SCHEMA_VERSION` (Python) and add a new section here for any breaking change to field set, types, or canonical rules. Old verifiers MUST reject newer versions until upgraded.

--- a/go-key-service/README.md
+++ b/go-key-service/README.md
@@ -1,0 +1,20 @@
+# go-key-service
+
+Go HTTP service for agent identity and Ed25519 key management.
+
+## Layout
+
+- `cmd/keyserver/` — entrypoint binary
+- `internal/action/` — canonical action schema + encoding (shared with `sdk-python`)
+
+## Run
+
+```sh
+go run ./cmd/keyserver
+```
+
+## Test
+
+```sh
+go test ./...
+```

--- a/go-key-service/cmd/keyserver/main.go
+++ b/go-key-service/cmd/keyserver/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+)
+
+func main() {
+	fmt.Printf("CryptoAgent key-service skeleton (schema v%d)\n", action.SchemaVersion)
+}

--- a/go-key-service/go.mod
+++ b/go-key-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/knhn1004/CryptoAgent/go-key-service
+
+go 1.25.0

--- a/go-key-service/internal/action/action.go
+++ b/go-key-service/internal/action/action.go
@@ -1,0 +1,86 @@
+// Package action defines the canonical agent action message and its
+// deterministic encoding. See docs/schema.md for the full contract.
+package action
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	SchemaVersion = 1
+	NonceHexLen   = 32
+	MaxSkewMillis = 30_000
+	NonceWindowMs = 600_000
+)
+
+type Action struct {
+	SchemaVersion int    `json:"schema_version"`
+	AgentID       string `json:"agent_id"`
+	ActionType    string `json:"action_type"`
+	Target        string `json:"target"`
+	TimestampMs   int64  `json:"timestamp"`
+	Nonce         string `json:"nonce"`
+}
+
+var (
+	ErrSchemaVersion = errors.New("action: unsupported schema_version")
+	ErrEmptyField    = errors.New("action: required field empty")
+	ErrNonceShape    = errors.New("action: nonce must be 32 lowercase hex chars")
+)
+
+// Validate checks structural invariants. Replay-window checks
+// (timestamp skew, nonce reuse) are the verifier's job.
+func (a *Action) Validate() error {
+	if a.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: got %d want %d", ErrSchemaVersion, a.SchemaVersion, SchemaVersion)
+	}
+	if a.AgentID == "" || a.ActionType == "" || a.Target == "" {
+		return ErrEmptyField
+	}
+	if len(a.Nonce) != NonceHexLen {
+		return ErrNonceShape
+	}
+	if _, err := hex.DecodeString(a.Nonce); err != nil {
+		return ErrNonceShape
+	}
+	for _, r := range a.Nonce {
+		if r >= 'A' && r <= 'F' {
+			return ErrNonceShape
+		}
+	}
+	return nil
+}
+
+// Canonical returns the deterministic JSON bytes used for signing
+// and hashing. Keys are sorted; no insignificant whitespace.
+func (a *Action) Canonical() ([]byte, error) {
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+	// encoding/json sorts map keys. Marshal via map to guarantee order
+	// independent of struct field declaration order.
+	m := map[string]any{
+		"schema_version": a.SchemaVersion,
+		"agent_id":       a.AgentID,
+		"action_type":    a.ActionType,
+		"target":         a.Target,
+		"timestamp":      a.TimestampMs,
+		"nonce":          a.Nonce,
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(m); err != nil {
+		return nil, err
+	}
+	// Encoder appends a trailing newline; strip it.
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}

--- a/go-key-service/internal/action/action_test.go
+++ b/go-key-service/internal/action/action_test.go
@@ -1,0 +1,83 @@
+package action
+
+import "testing"
+
+func sample() Action {
+	return Action{
+		SchemaVersion: 1,
+		AgentID:       "agent-001",
+		ActionType:    "ping",
+		Target:        "peer-002",
+		TimestampMs:   1700000000000,
+		Nonce:         "0123456789abcdef0123456789abcdef",
+	}
+}
+
+func TestCanonicalReferenceVector(t *testing.T) {
+	a := sample()
+	want := `{"action_type":"ping","agent_id":"agent-001","nonce":"0123456789abcdef0123456789abcdef","schema_version":1,"target":"peer-002","timestamp":1700000000000}`
+	got, err := a.Canonical()
+	if err != nil {
+		t.Fatalf("Canonical: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("canonical mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestCanonicalDeterministic(t *testing.T) {
+	a := sample()
+	first, err := a.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		again, err := a.Canonical()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(first) != string(again) {
+			t.Fatalf("non-deterministic encoding")
+		}
+	}
+}
+
+func TestValidateRejectsBadNonce(t *testing.T) {
+	cases := map[string]string{
+		"too_short":  "deadbeef",
+		"upper_hex":  "0123456789ABCDEF0123456789abcdef",
+		"non_hex":    "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+		"with_space": "0123456789abcdef0123456789abcde ",
+	}
+	for name, n := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := sample()
+			a.Nonce = n
+			if err := a.Validate(); err == nil {
+				t.Fatalf("expected ErrNonceShape, got nil")
+			}
+		})
+	}
+}
+
+func TestValidateRejectsWrongSchemaVersion(t *testing.T) {
+	a := sample()
+	a.SchemaVersion = 2
+	if err := a.Validate(); err == nil {
+		t.Fatal("expected ErrSchemaVersion")
+	}
+}
+
+func TestValidateRejectsEmptyFields(t *testing.T) {
+	for _, mut := range []func(*Action){
+		func(a *Action) { a.AgentID = "" },
+		func(a *Action) { a.ActionType = "" },
+		func(a *Action) { a.Target = "" },
+	} {
+		a := sample()
+		mut(&a)
+		if err := a.Validate(); err == nil {
+			t.Fatal("expected ErrEmptyField")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/adarshm11/CryptoAgent
-
-go 1.25.0

--- a/main.go
+++ b/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Hello, World!")
-}

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -1,0 +1,21 @@
+# cryptoagent (Python SDK)
+
+Client SDK for CryptoAgent — canonical action schema, signing helpers, and LangChain decorators.
+
+## Install (dev)
+
+```sh
+pip install -e ".[dev]"
+```
+
+## Test
+
+```sh
+pytest
+```
+
+## Lint
+
+```sh
+ruff check .
+```

--- a/sdk-python/cryptoagent/__init__.py
+++ b/sdk-python/cryptoagent/__init__.py
@@ -1,0 +1,9 @@
+from .action import MAX_SKEW_MS, NONCE_HEX_LEN, NONCE_WINDOW_MS, SCHEMA_VERSION, Action
+
+__all__ = [
+    "Action",
+    "SCHEMA_VERSION",
+    "NONCE_HEX_LEN",
+    "MAX_SKEW_MS",
+    "NONCE_WINDOW_MS",
+]

--- a/sdk-python/cryptoagent/action.py
+++ b/sdk-python/cryptoagent/action.py
@@ -1,0 +1,62 @@
+"""Canonical agent action message.
+
+Mirror of go-key-service/internal/action/action.go. See docs/schema.md
+for the contract; both libraries MUST produce byte-identical canonical
+encodings for equal inputs.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+SCHEMA_VERSION = 1
+NONCE_HEX_LEN = 32
+MAX_SKEW_MS = 30_000
+NONCE_WINDOW_MS = 600_000
+
+_HEX_LOWER = set("0123456789abcdef")
+
+
+class ActionError(ValueError):
+    """Base class for action validation errors."""
+
+
+@dataclass(frozen=True)
+class Action:
+    schema_version: int
+    agent_id: str
+    action_type: str
+    target: str
+    timestamp_ms: int
+    nonce: str
+
+    def validate(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ActionError(
+                f"unsupported schema_version: got {self.schema_version} want {SCHEMA_VERSION}"
+            )
+        if not self.agent_id or not self.action_type or not self.target:
+            raise ActionError("required field empty")
+        if len(self.nonce) != NONCE_HEX_LEN or any(c not in _HEX_LOWER for c in self.nonce):
+            raise ActionError("nonce must be 32 lowercase hex chars")
+        if not isinstance(self.timestamp_ms, int) or isinstance(self.timestamp_ms, bool):
+            raise ActionError("timestamp must be int milliseconds")
+
+    def canonical(self) -> bytes:
+        """Deterministic JSON bytes used for signing and hashing."""
+        self.validate()
+        payload = {
+            "action_type": self.action_type,
+            "agent_id": self.agent_id,
+            "nonce": self.nonce,
+            "schema_version": self.schema_version,
+            "target": self.target,
+            "timestamp": self.timestamp_ms,
+        }
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "cryptoagent"
+version = "0.1.0"
+description = "CryptoAgent Python SDK — signed actions, multi-sig helpers, LangChain decorators"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "ruff>=0.6",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["cryptoagent*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/sdk-python/tests/test_action.py
+++ b/sdk-python/tests/test_action.py
@@ -1,0 +1,80 @@
+import pytest
+
+from cryptoagent.action import Action, ActionError
+
+
+def sample() -> Action:
+    return Action(
+        schema_version=1,
+        agent_id="agent-001",
+        action_type="ping",
+        target="peer-002",
+        timestamp_ms=1700000000000,
+        nonce="0123456789abcdef0123456789abcdef",
+    )
+
+
+def test_canonical_reference_vector() -> None:
+    want = (
+        b'{"action_type":"ping","agent_id":"agent-001",'
+        b'"nonce":"0123456789abcdef0123456789abcdef",'
+        b'"schema_version":1,"target":"peer-002","timestamp":1700000000000}'
+    )
+    assert sample().canonical() == want
+
+
+def test_canonical_deterministic() -> None:
+    a = sample()
+    first = a.canonical()
+    for _ in range(10):
+        assert a.canonical() == first
+
+
+@pytest.mark.parametrize(
+    "bad_nonce",
+    [
+        "deadbeef",
+        "0123456789ABCDEF0123456789abcdef",
+        "Z" * 32,
+        "0123456789abcdef0123456789abcde ",
+    ],
+)
+def test_validate_rejects_bad_nonce(bad_nonce: str) -> None:
+    a = Action(
+        schema_version=1,
+        agent_id="x",
+        action_type="y",
+        target="z",
+        timestamp_ms=0,
+        nonce=bad_nonce,
+    )
+    with pytest.raises(ActionError):
+        a.validate()
+
+
+def test_validate_rejects_wrong_schema_version() -> None:
+    a = Action(
+        schema_version=2,
+        agent_id="x",
+        action_type="y",
+        target="z",
+        timestamp_ms=0,
+        nonce="0" * 32,
+    )
+    with pytest.raises(ActionError):
+        a.validate()
+
+
+@pytest.mark.parametrize("field", ["agent_id", "action_type", "target"])
+def test_validate_rejects_empty_required_field(field: str) -> None:
+    kwargs = dict(
+        schema_version=1,
+        agent_id="x",
+        action_type="y",
+        target="z",
+        timestamp_ms=0,
+        nonce="0" * 32,
+    )
+    kwargs[field] = ""
+    with pytest.raises(ActionError):
+        Action(**kwargs).validate()


### PR DESCRIPTION
## Summary
- Closes #5 — repo scaffolding & CI pipeline
- Closes #8 — agent message & action schema

## Acceptance — #5
- [x] Top-level dirs: `go-key-service/`, `sdk-python/`, `dashboard/`, `contracts/`, `docs/`
- [x] GitHub Actions: Go build+test, Python lint+test, TS build, contract compile (dashboard/contracts gated until scaffolded)
- [x] PR template + CODEOWNERS
- [x] Pre-commit / formatter config (gofmt, ruff, prettier)

## Acceptance — #8
- [x] `action = {agent_id, action_type, target, timestamp, nonce}` (+ `schema_version` per docs)
- [x] Deterministic canonical encoding (sorted-key JSON, no whitespace)
- [x] Shared schema published for Go + Python consumers (`go-key-service/internal/action`, `sdk-python/cryptoagent/action.py`, `docs/schema.md`)
- [x] Replay-protection contract documented (±30 s ts skew, 600 s nonce window)

## Cross-language correctness
Both implementations produce byte-identical canonical bytes for the reference vector in `docs/schema.md`. Unit tests in both languages assert against the same fixture string.

## Test plan
- [x] `cd go-key-service && go vet ./... && go test ./...` — passes
- [x] `cd sdk-python && pytest -q` — 10 passed
- [x] `cd sdk-python && ruff check . && ruff format --check .` — clean
- [ ] CI green on this PR

## Notes for reviewers
- Module path changed from `github.com/adarshm11/CryptoAgent` to `github.com/knhn1004/CryptoAgent/go-key-service` to match the actual repo + future workspace layout. Happy to adjust if @adarshm11 wants the org/repo elsewhere.
- Dashboard + contracts CI jobs are gated on the presence of `package.json` / `foundry.toml` so they pass cleanly until those subprojects get scaffolded in their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)