### PR TITLE
Ed25519 keypair generation & registration API

### DIFF
--- a/go-key-service/internal/httpapi/handlers.go
+++ b/go-key-service/internal/httpapi/handlers.go
@@ -33,6 +33,8 @@ func (s *Server) Router() http.Handler {
 	r.Route("/v1/keys", func(r chi.Router) {
 		r.Get("/", s.handleList)
 		r.Post("/", s.handleCreate)
+		r.Post("/agents", s.handleAgents)
+		r.Get("/agents/{agentID}/pubkey", s.handleGetAgentPubKey)
 		r.Get("/{agentID}", s.handleGet)
 		r.Delete("/{agentID}", s.handleDelete)
 	})
@@ -108,6 +110,42 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		AgentID string `json:"agent_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+	if body.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "agent_id is required")
+		return
+	}
+	pub, err := s.store.Create(r.Context(), body.AgentID)
+	if err != nil {
+		s.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, keyResponse{
+		AgentID:   body.AgentID,
+		PublicKey: hex.EncodeToString(pub),
+	})
+}
+
+func (s *Server) handleGetAgentPubKey(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "agentID")
+	pub, _, err := s.store.Get(r.Context(), id)
+	if err != nil {
+		s.writeStoreError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, keyResponse{
+		AgentID:   id,
+		PublicKey: hex.EncodeToString(pub),
+	})
 }
 
 func (s *Server) writeStoreError(w http.ResponseWriter, err error) {

--- a/go-key-service/internal/httpapi/handlers_test.go
+++ b/go-key-service/internal/httpapi/handlers_test.go
@@ -126,6 +126,77 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestAgentsCreateAndGetPubKey(t *testing.T) {
+	h := newTestServer().Router()
+
+	rec, body := do(t, h, http.MethodPost, "/v1/keys/agents", map[string]string{"agent_id": "agent1"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status: got %d want 201", rec.Code)
+	}
+	pub, _ := body["public_key"].(string)
+	if len(pub) != 64 {
+		t.Fatalf("public_key hex length: got %d", len(pub))
+	}
+	if body["agent_id"] != "agent1" {
+		t.Fatalf("agent_id: %v", body["agent_id"])
+	}
+
+	rec, body = do(t, h, http.MethodGet, "/v1/keys/agents/agent1/pubkey", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get status: got %d want 200", rec.Code)
+	}
+	if body["public_key"] != pub {
+		t.Fatal("get returned different public key")
+	}
+	if body["agent_id"] != "agent1" {
+		t.Fatalf("agent_id: %v", body["agent_id"])
+	}
+}
+
+func TestAgentsCreateMissingField(t *testing.T) {
+	h := newTestServer().Router()
+	rec, body := do(t, h, http.MethodPost, "/v1/keys/agents", map[string]string{})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+	if body["error"] != "missing_field" {
+		t.Fatalf("error code: %v", body["error"])
+	}
+}
+
+func TestAgentsCreateBadJSON(t *testing.T) {
+	h := newTestServer().Router()
+	req := httptest.NewRequest(http.MethodPost, "/v1/keys/agents", bytes.NewReader([]byte("not-json")))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+}
+
+func TestAgentsCreateDuplicate(t *testing.T) {
+	h := newTestServer().Router()
+	do(t, h, http.MethodPost, "/v1/keys/agents", map[string]string{"agent_id": "dup"})
+	rec, body := do(t, h, http.MethodPost, "/v1/keys/agents", map[string]string{"agent_id": "dup"})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409", rec.Code)
+	}
+	if body["error"] != "already_exists" {
+		t.Fatalf("error code: %v", body["error"])
+	}
+}
+
+func TestGetAgentPubKeyMissing(t *testing.T) {
+	h := newTestServer().Router()
+	rec, body := do(t, h, http.MethodGet, "/v1/keys/agents/nope/pubkey", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", rec.Code)
+	}
+	if body["error"] != "not_found" {
+		t.Fatalf("error code: %v", body["error"])
+	}
+}
+
 func TestDelete(t *testing.T) {
 	h := newTestServer().Router()
 	do(t, h, http.MethodPost, "/v1/keys", map[string]string{"agent_id": "rm"})


### PR DESCRIPTION
## Summary

This PR creates two new API routes in `go-key-service/internal/httpapi/handlers.go`: 
- `POST /agents` : creates a keypair for an agent (given its ID)
- `GET /agents/:id/pubkey` : retrieves an agent's public key (given its ID)

Resolves #7 

## Acceptance checklist

<!-- Copy the acceptance bullets from the linked issue and tick them. -->

- [x] POST /agents → returns agent_id + public key, stores private key securely
- [x] GET /agents/:id/pubkey → public key lookup
- [x] Ed25519 via crypto/ed25519
- [x] Tests covering generation, lookup, and idempotent re-registration rejection

## Test plan

- [ ] `go test ./...` (in `go-key-service/`)

## Notes for reviewers

Confirm that the body for the `/agents/` POST route is expected to be the agent's ID, and comment on the review if this needs to be updated.
