### PR TITLE
feat(audit): action verification + merkle append pipeline (#11)

### DIFF
--- a/go-key-service/cmd/keyserver/main.go
+++ b/go-key-service/cmd/keyserver/main.go
@@ -11,9 +11,11 @@ import (
 	"time"
 
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/config"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/httpapi"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/merkle"
 )
 
 func main() {
@@ -28,9 +30,11 @@ func main() {
 	logger.Info("starting", "addr", cfg.Addr, "schema_version", action.SchemaVersion)
 
 	store := keystore.NewMemory()
+	tree := merkle.New()
+	pipeline := auditlog.New(tree, store)
 	srv := &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           httpapi.NewServer(store, logger).Router(),
+		Handler:           httpapi.NewServer(store, logger).WithAuditPipeline(pipeline).Router(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/go-key-service/internal/auditlog/http/handler.go
+++ b/go-key-service/internal/auditlog/http/handler.go
@@ -1,0 +1,195 @@
+// Package auditloghttp exposes the audit-log Pipeline over HTTP. The
+// keyserver mounts this handler under /v1/audit so the dashboard can
+// submit signed actions and tail the resulting indexed events.
+package auditloghttp
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
+)
+
+// Handler returns an http.Handler exposing the append and event-stream
+// endpoints for the given pipeline.
+func Handler(p *auditlog.Pipeline, logger *slog.Logger) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &handler{p: p, logger: logger}
+	r := chi.NewRouter()
+	r.Post("/v1/audit/append", h.append)
+	r.Get("/v1/audit/events", h.stream)
+	return r
+}
+
+// Mount attaches the audit endpoints onto an existing chi.Router so the
+// keyserver can keep all v1 routes on a single router.
+func Mount(r chi.Router, p *auditlog.Pipeline, logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &handler{p: p, logger: logger}
+	r.Post("/v1/audit/append", h.append)
+	r.Get("/v1/audit/events", h.stream)
+}
+
+type handler struct {
+	p      *auditlog.Pipeline
+	logger *slog.Logger
+}
+
+type appendRequest struct {
+	Action    *action.Action `json:"action"`
+	Signature string         `json:"signature"`
+}
+
+type appendResponse struct {
+	auditlog.Event
+	Idempotent bool `json:"idempotent"`
+}
+
+// MarshalJSON merges the embedded Event's hex-encoded fields with the
+// idempotent flag in a single object.
+func (r appendResponse) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal(r.Event)
+	if err != nil {
+		return nil, err
+	}
+	// Splice in idempotent before the closing brace.
+	if len(b) < 2 || b[len(b)-1] != '}' {
+		return nil, fmt.Errorf("auditloghttp: unexpected event json: %s", b)
+	}
+	tail := fmt.Sprintf(`,"idempotent":%t}`, r.Idempotent)
+	return append(b[:len(b)-1], tail...), nil
+}
+
+func (h *handler) append(w http.ResponseWriter, r *http.Request) {
+	var req appendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+	if req.Action == nil {
+		writeError(w, http.StatusBadRequest, "missing_field", "action is required")
+		return
+	}
+	sig, err := hex.DecodeString(req.Signature)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_signature_hex", err.Error())
+		return
+	}
+
+	ev, fresh, err := h.p.Submit(r.Context(), req.Action, sig)
+	if err != nil {
+		h.writePipelineError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, appendResponse{Event: *ev, Idempotent: !fresh})
+}
+
+func (h *handler) stream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "no_flush", "streaming unsupported")
+		return
+	}
+
+	since := uint64(0)
+	if v := r.URL.Query().Get("since"); v != "" {
+		var parsed uint64
+		if _, err := fmt.Sscanf(v, "%d", &parsed); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_since", err.Error())
+			return
+		}
+		since = parsed
+	}
+
+	ch, cancel := h.p.Subscribe()
+	defer cancel()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	// Replay backlog first. Track the highest delivered index so we can
+	// suppress duplicates that may have arrived between EventsSince and
+	// Subscribe.
+	var lastSent int64 = int64(since) - 1
+	for _, ev := range h.p.EventsSince(since) {
+		if err := writeSSE(w, ev); err != nil {
+			return
+		}
+		lastSent = int64(ev.LeafIndex)
+	}
+	flusher.Flush()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if int64(ev.LeafIndex) <= lastSent {
+				continue
+			}
+			if err := writeSSE(w, ev); err != nil {
+				return
+			}
+			lastSent = int64(ev.LeafIndex)
+			flusher.Flush()
+		}
+	}
+}
+
+func writeSSE(w http.ResponseWriter, ev auditlog.Event) error {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "id: %d\ndata: %s\n\n", ev.LeafIndex, b); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *handler) writePipelineError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, auditlog.ErrUnknownAgent):
+		writeError(w, http.StatusNotFound, "unknown_agent", err.Error())
+	case errors.Is(err, auditlog.ErrInvalidSignature):
+		writeError(w, http.StatusUnauthorized, "invalid_signature", err.Error())
+	case errors.Is(err, auditlog.ErrSchemaVersion):
+		writeError(w, http.StatusUnprocessableEntity, "schema_version", err.Error())
+	case errors.Is(err, auditlog.ErrTimestampSkew):
+		writeError(w, http.StatusUnprocessableEntity, "timestamp_skew", err.Error())
+	case errors.Is(err, action.ErrEmptyField), errors.Is(err, action.ErrNonceShape):
+		writeError(w, http.StatusBadRequest, "invalid_action", err.Error())
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		writeError(w, http.StatusRequestTimeout, "canceled", err.Error())
+	default:
+		h.logger.Error("auditlog submit", "err", err)
+		writeError(w, http.StatusInternalServerError, "internal", "internal error")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, map[string]string{"error": code, "message": msg})
+}

--- a/go-key-service/internal/auditlog/http/handler.go
+++ b/go-key-service/internal/auditlog/http/handler.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
@@ -104,8 +105,8 @@ func (h *handler) stream(w http.ResponseWriter, r *http.Request) {
 
 	since := uint64(0)
 	if v := r.URL.Query().Get("since"); v != "" {
-		var parsed uint64
-		if _, err := fmt.Sscanf(v, "%d", &parsed); err != nil {
+		parsed, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_since", err.Error())
 			return
 		}

--- a/go-key-service/internal/auditlog/http/handler_test.go
+++ b/go-key-service/internal/auditlog/http/handler_test.go
@@ -1,0 +1,273 @@
+package auditloghttp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/merkle"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/signing"
+)
+
+func makeAction(agentID string, tsMs int64, nonce string) *action.Action {
+	return &action.Action{
+		SchemaVersion: action.SchemaVersion,
+		AgentID:       agentID,
+		ActionType:    "ping",
+		Target:        "peer-002",
+		TimestampMs:   tsMs,
+		Nonce:         nonce,
+	}
+}
+
+func newHarness(t *testing.T) (http.Handler, *auditlog.Pipeline, keystore.KeyStore, time.Time) {
+	t.Helper()
+	now := time.UnixMilli(1_700_000_000_000)
+	store := keystore.NewMemory()
+	tree := merkle.New()
+	p := auditlog.New(tree, store, auditlog.WithClock(func() time.Time { return now }))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return Handler(p, logger), p, store, now
+}
+
+func registerAgent(t *testing.T, store keystore.KeyStore, id string) (pub, priv []byte) {
+	t.Helper()
+	if _, err := store.Create(context.Background(), id); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	p, k, err := store.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	return p, k
+}
+
+func TestAppendHappyPath(t *testing.T) {
+	h, _, store, now := newHarness(t)
+	_, priv := registerAgent(t, store, "agent-1")
+
+	a := makeAction("agent-1", now.UnixMilli(), "0123456789abcdef0123456789abcdef")
+	sig, err := signing.Sign(a, priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"action":    a,
+		"signature": hex.EncodeToString(sig),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/audit/append", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rec.Body.String())
+	}
+	if got["idempotent"] != false {
+		t.Fatalf("idempotent: got %v want false", got["idempotent"])
+	}
+	if got["leaf_index"].(float64) != 0 {
+		t.Fatalf("leaf_index: got %v want 0", got["leaf_index"])
+	}
+	if got["leaf_hash"] == "" {
+		t.Fatal("leaf_hash empty")
+	}
+}
+
+func TestAppendDuplicateReturnsIdempotent(t *testing.T) {
+	h, _, store, now := newHarness(t)
+	_, priv := registerAgent(t, store, "agent-1")
+
+	a := makeAction("agent-1", now.UnixMilli(), "0123456789abcdef0123456789abcdef")
+	sig, _ := signing.Sign(a, priv)
+	body, _ := json.Marshal(map[string]any{
+		"action":    a,
+		"signature": hex.EncodeToString(sig),
+	})
+
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/audit/append", bytes.NewReader(body))
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first status: %d body=%s", rec1.Code, rec1.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/audit/append", bytes.NewReader(body))
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("dup status: %d", rec2.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["idempotent"] != true {
+		t.Fatalf("idempotent: got %v want true", got["idempotent"])
+	}
+}
+
+func TestAppendBadSignature(t *testing.T) {
+	h, _, store, now := newHarness(t)
+	registerAgent(t, store, "agent-1")
+
+	a := makeAction("agent-1", now.UnixMilli(), "0123456789abcdef0123456789abcdef")
+	bad := bytes.Repeat([]byte{0xAA}, 64)
+	body, _ := json.Marshal(map[string]any{
+		"action":    a,
+		"signature": hex.EncodeToString(bad),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/audit/append", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401, body=%s", rec.Code, rec.Body.String())
+	}
+	var env map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env["error"] != "invalid_signature" {
+		t.Fatalf("error code: %v", env["error"])
+	}
+}
+
+func TestAppendUnknownAgent(t *testing.T) {
+	h, _, store, now := newHarness(t)
+	_, priv := registerAgent(t, store, "agent-other")
+
+	a := makeAction("agent-missing", now.UnixMilli(), "0123456789abcdef0123456789abcdef")
+	sig, _ := signing.Sign(a, priv)
+	body, _ := json.Marshal(map[string]any{
+		"action":    a,
+		"signature": hex.EncodeToString(sig),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/audit/append", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAppendBadJSON(t *testing.T) {
+	h, _, _, _ := newHarness(t)
+	req := httptest.NewRequest(http.MethodPost, "/v1/audit/append", bytes.NewReader([]byte("not-json")))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+}
+
+func TestEventStreamReplaysAndTails(t *testing.T) {
+	h, p, store, now := newHarness(t)
+	_, priv := registerAgent(t, store, "agent-1")
+
+	// Pre-populate two events so the stream has history to replay.
+	for i, nonce := range []string{
+		"00000000000000000000000000000001",
+		"00000000000000000000000000000002",
+	} {
+		a := makeAction("agent-1", now.UnixMilli(), nonce)
+		sig, _ := signing.Sign(a, priv)
+		if _, _, err := p.Submit(context.Background(), a, sig); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/v1/audit/events?since=0", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status: %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("content-type: %q", ct)
+	}
+
+	rd := bufio.NewReader(resp.Body)
+	got := readSSEEvents(t, rd, 2)
+	if len(got) != 2 {
+		t.Fatalf("replay: got %d want 2", len(got))
+	}
+	if got[0]["leaf_index"].(float64) != 0 || got[1]["leaf_index"].(float64) != 1 {
+		t.Fatalf("replay order: %+v", got)
+	}
+
+	// Push a live event and read it from the stream.
+	a := makeAction("agent-1", now.UnixMilli(), "00000000000000000000000000000003")
+	sig, _ := signing.Sign(a, priv)
+	if _, _, err := p.Submit(context.Background(), a, sig); err != nil {
+		t.Fatalf("live submit: %v", err)
+	}
+	live := readSSEEvents(t, rd, 1)
+	if len(live) != 1 || live[0]["leaf_index"].(float64) != 2 {
+		t.Fatalf("live: %+v", live)
+	}
+}
+
+// readSSEEvents reads up to n SSE `data:` events from rd, with a per-event
+// timeout. It assumes one JSON object per `data:` line and a blank line
+// delimiter between events.
+func readSSEEvents(t *testing.T, rd *bufio.Reader, n int) []map[string]any {
+	t.Helper()
+	out := make([]map[string]any, 0, n)
+	type line struct {
+		s   string
+		err error
+	}
+	deadline := time.After(3 * time.Second)
+	lineCh := make(chan line, 1)
+
+	for len(out) < n {
+		go func() {
+			s, err := rd.ReadString('\n')
+			lineCh <- line{s, err}
+		}()
+		select {
+		case ln := <-lineCh:
+			if ln.err != nil {
+				t.Fatalf("read: %v", ln.err)
+			}
+			s := strings.TrimRight(ln.s, "\r\n")
+			if !strings.HasPrefix(s, "data:") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(s, "data:"))
+			var m map[string]any
+			if err := json.Unmarshal([]byte(payload), &m); err != nil {
+				t.Fatalf("sse json: %v line=%q", err, payload)
+			}
+			out = append(out, m)
+		case <-deadline:
+			t.Fatalf("timeout waiting for %d events; got %d", n, len(out))
+		}
+	}
+	return out
+}

--- a/go-key-service/internal/auditlog/pipeline.go
+++ b/go-key-service/internal/auditlog/pipeline.go
@@ -102,8 +102,13 @@ type Pipeline struct {
 
 	subBuffer int
 
-	mu     sync.Mutex
-	seen   map[string]*Event
+	mu   sync.Mutex
+	seen map[string]*Event
+	// events retains every appended Event so EventsSince() can backfill
+	// reconnecting subscribers. Bounded only by process lifetime — fine
+	// for the in-memory scope of the current service. A ring buffer or an
+	// external store is the right next step before a long-running
+	// production deployment.
 	events []*Event
 	subs   map[uint64]chan Event
 	nextID uint64

--- a/go-key-service/internal/auditlog/pipeline.go
+++ b/go-key-service/internal/auditlog/pipeline.go
@@ -1,0 +1,295 @@
+// Package auditlog wires verified agent actions into the append-only
+// Merkle tree. It owns the replay-protection cache (keyed by
+// agent_id+nonce) and a fan-out of indexed events so downstream
+// consumers (the dashboard, the on-chain anchor job) can tail the log.
+//
+// Per docs/schema.md, the leaf payload is canonical(action) || signature
+// and the replay window is 30 s skew + 600 s nonce window.
+package auditlog
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/merkle"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/signing"
+)
+
+// Sentinel errors. ErrInvalidSignature wraps the signing package's value
+// so callers can errors.Is against either.
+var (
+	ErrSchemaVersion    = action.ErrSchemaVersion
+	ErrTimestampSkew    = errors.New("auditlog: timestamp outside accepted skew window")
+	ErrUnknownAgent     = errors.New("auditlog: unknown agent")
+	ErrInvalidSignature = signing.ErrInvalidSignature
+)
+
+// Event is the indexed record emitted to subscribers and persisted in
+// the in-memory append log. JSON tags match the dashboard contract.
+type Event struct {
+	LeafIndex  uint64            `json:"leaf_index"`
+	LeafHash   []byte            `json:"leaf_hash"`
+	Action     *action.Action    `json:"action"`
+	Signature  []byte            `json:"signature"`
+	PublicKey  ed25519.PublicKey `json:"public_key"`
+	RecordedAt time.Time         `json:"recorded_at"`
+}
+
+// MarshalJSON encodes the byte slices as hex so the dashboard can render
+// them without an extra base64 step.
+func (e Event) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		LeafIndex  uint64         `json:"leaf_index"`
+		LeafHash   string         `json:"leaf_hash"`
+		Action     *action.Action `json:"action"`
+		Signature  string         `json:"signature"`
+		PublicKey  string         `json:"public_key"`
+		RecordedAt time.Time      `json:"recorded_at"`
+	}{
+		LeafIndex:  e.LeafIndex,
+		LeafHash:   hexEncode(e.LeafHash),
+		Action:     e.Action,
+		Signature:  hexEncode(e.Signature),
+		PublicKey:  hexEncode(e.PublicKey),
+		RecordedAt: e.RecordedAt,
+	})
+}
+
+// Option configures the Pipeline at construction time.
+type Option func(*Pipeline)
+
+// WithClock injects a clock; tests pin time, production uses time.Now.
+func WithClock(now func() time.Time) Option {
+	return func(p *Pipeline) {
+		if now != nil {
+			p.now = now
+		}
+	}
+}
+
+// WithSubscriberBuffer overrides the per-subscriber channel buffer size.
+func WithSubscriberBuffer(n int) Option {
+	return func(p *Pipeline) {
+		if n > 0 {
+			p.subBuffer = n
+		}
+	}
+}
+
+// Pipeline verifies signed actions and appends them to a Merkle tree.
+//
+// Idempotency: a small map keyed by (agent_id, nonce) caches the first
+// Event observed for each pair. Entries are evicted lazily on read once
+// they fall outside the replay window (skew + nonce window). This keeps
+// the implementation simple — no background goroutine — at the cost of
+// holding stale entries until a duplicate query touches them. For the
+// expected throughput of this service that trade-off is acceptable.
+//
+// Back-pressure: each subscriber gets a small buffered channel. If the
+// buffer is full, the pipeline drops the event for that subscriber
+// rather than blocking the append path. Slow consumers therefore lose
+// events; they should re-sync via EventsSince on reconnect.
+type Pipeline struct {
+	tree  *merkle.Tree
+	store keystore.KeyStore
+	now   func() time.Time
+
+	subBuffer int
+
+	mu     sync.Mutex
+	seen   map[string]*Event
+	events []*Event
+	subs   map[uint64]chan Event
+	nextID uint64
+}
+
+// New constructs a Pipeline. Both tree and store are required.
+func New(tree *merkle.Tree, store keystore.KeyStore, opts ...Option) *Pipeline {
+	p := &Pipeline{
+		tree:      tree,
+		store:     store,
+		now:       time.Now,
+		subBuffer: 16,
+		seen:      make(map[string]*Event),
+		subs:      make(map[uint64]chan Event),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Submit verifies and appends the action. The bool return is true when
+// a new leaf was appended, false when the call hit the idempotency cache
+// (in which case the cached Event is returned with a nil error).
+func (p *Pipeline) Submit(ctx context.Context, a *action.Action, sig []byte) (*Event, bool, error) {
+	if a == nil {
+		return nil, false, ErrSchemaVersion
+	}
+
+	if a.SchemaVersion != action.SchemaVersion {
+		return nil, false, ErrSchemaVersion
+	}
+	if err := a.Validate(); err != nil {
+		return nil, false, err
+	}
+
+	now := p.now()
+	if skew := absInt64(now.UnixMilli() - a.TimestampMs); skew > action.MaxSkewMillis {
+		return nil, false, ErrTimestampSkew
+	}
+
+	pub, _, err := p.store.Get(ctx, a.AgentID)
+	if err != nil {
+		if errors.Is(err, keystore.ErrNotFound) {
+			return nil, false, ErrUnknownAgent
+		}
+		return nil, false, err
+	}
+
+	if err := signing.Verify(a, sig, pub); err != nil {
+		return nil, false, err
+	}
+
+	canon, err := a.Canonical()
+	if err != nil {
+		return nil, false, err
+	}
+
+	key := replayKey(a.AgentID, a.Nonce)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if cached, ok := p.seen[key]; ok {
+		if !p.expired(cached.RecordedAt, now) {
+			return cached, false, nil
+		}
+		// Stale — fall through and treat as a fresh append.
+		delete(p.seen, key)
+	}
+
+	leafPayload := make([]byte, 0, len(canon)+len(sig))
+	leafPayload = append(leafPayload, canon...)
+	leafPayload = append(leafPayload, sig...)
+
+	idx := p.tree.Append(leafPayload)
+	ev := &Event{
+		LeafIndex:  idx,
+		LeafHash:   merkle.HashLeaf(leafPayload),
+		Action:     copyAction(a),
+		Signature:  copyBytes(sig),
+		PublicKey:  copyBytes(pub),
+		RecordedAt: now,
+	}
+	p.seen[key] = ev
+	p.events = append(p.events, ev)
+
+	for _, ch := range p.subs {
+		select {
+		case ch <- *ev:
+		default:
+			// Subscriber too slow; drop. They can re-sync via EventsSince.
+		}
+	}
+
+	return ev, true, nil
+}
+
+// Subscribe registers a new subscriber and returns its channel plus a
+// cancel function. The cancel function unregisters the subscriber and
+// closes the channel; it is safe to call more than once.
+func (p *Pipeline) Subscribe() (<-chan Event, func()) {
+	ch := make(chan Event, p.subBuffer)
+	p.mu.Lock()
+	id := p.nextID
+	p.nextID++
+	p.subs[id] = ch
+	p.mu.Unlock()
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			p.mu.Lock()
+			if c, ok := p.subs[id]; ok {
+				delete(p.subs, id)
+				close(c)
+			}
+			p.mu.Unlock()
+		})
+	}
+	return ch, cancel
+}
+
+// EventsSince returns all events with leaf index >= since, in append
+// order. Used by the SSE handler to backfill before tailing live events.
+func (p *Pipeline) EventsSince(since uint64) []Event {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if since >= uint64(len(p.events)) {
+		return nil
+	}
+	out := make([]Event, 0, uint64(len(p.events))-since)
+	for _, e := range p.events[since:] {
+		out = append(out, *e)
+	}
+	return out
+}
+
+// Size reports the current number of recorded events. Equal to tree size.
+func (p *Pipeline) Size() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return uint64(len(p.events))
+}
+
+func (p *Pipeline) expired(recordedAt, now time.Time) bool {
+	window := time.Duration(action.MaxSkewMillis+action.NonceWindowMs) * time.Millisecond
+	return now.Sub(recordedAt) > window
+}
+
+func replayKey(agentID, nonce string) string {
+	return agentID + "|" + nonce
+}
+
+func copyBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}
+
+func copyAction(a *action.Action) *action.Action {
+	if a == nil {
+		return nil
+	}
+	cp := *a
+	return &cp
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// hexEncode is split out so we don't pull encoding/hex into the hot path
+// for callers that never marshal. Tiny enough to inline.
+func hexEncode(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, v := range b {
+		out[i*2] = hexdigits[v>>4]
+		out[i*2+1] = hexdigits[v&0x0f]
+	}
+	return string(out)
+}

--- a/go-key-service/internal/auditlog/pipeline_test.go
+++ b/go-key-service/internal/auditlog/pipeline_test.go
@@ -1,0 +1,365 @@
+package auditlog
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/merkle"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/signing"
+)
+
+// fixedClock returns a constant time so tests can construct actions with
+// stable timestamps and not race the wall clock.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// newAgent registers an agent in the store and returns its keys + id.
+func newAgent(t *testing.T, store keystore.KeyStore, id string) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	if _, err := store.Create(context.Background(), id); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	pub, priv, err := store.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	return pub, priv
+}
+
+func randNonce(t *testing.T) string {
+	t.Helper()
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func makeAction(agentID string, tsMs int64, nonce string) *action.Action {
+	return &action.Action{
+		SchemaVersion: action.SchemaVersion,
+		AgentID:       agentID,
+		ActionType:    "ping",
+		Target:        "peer-002",
+		TimestampMs:   tsMs,
+		Nonce:         nonce,
+	}
+}
+
+func newPipelineAt(t *testing.T, now time.Time) (*Pipeline, keystore.KeyStore, *merkle.Tree) {
+	t.Helper()
+	store := keystore.NewMemory()
+	tree := merkle.New()
+	p := New(tree, store, WithClock(fixedClock(now)))
+	return p, store, tree
+}
+
+func TestSubmitHappyPath(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, tree := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+	sig, err := signing.Sign(a, priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	ev, fresh, err := p.Submit(context.Background(), a, sig)
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if !fresh {
+		t.Fatal("expected fresh=true on first submit")
+	}
+	if ev.LeafIndex != 0 {
+		t.Fatalf("leaf index: got %d want 0", ev.LeafIndex)
+	}
+	if tree.Size() != 1 {
+		t.Fatalf("tree size: got %d want 1", tree.Size())
+	}
+
+	canon, err := a.Canonical()
+	if err != nil {
+		t.Fatalf("canonical: %v", err)
+	}
+	want := merkle.HashLeaf(append(canon, sig...))
+	if !bytes.Equal(ev.LeafHash, want) {
+		t.Fatalf("leaf hash mismatch:\n got  %x\n want %x", ev.LeafHash, want)
+	}
+	if !bytes.Equal(ev.Signature, sig) {
+		t.Fatal("event signature mismatch")
+	}
+	if ev.Action == nil || ev.Action.AgentID != "agent-1" {
+		t.Fatalf("event action wrong: %+v", ev.Action)
+	}
+	if ev.RecordedAt.IsZero() {
+		t.Fatal("RecordedAt unset")
+	}
+}
+
+func TestSubmitIdempotentSameAction(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, tree := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+	sig, err := signing.Sign(a, priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	first, fresh1, err := p.Submit(context.Background(), a, sig)
+	if err != nil || !fresh1 {
+		t.Fatalf("first submit: fresh=%v err=%v", fresh1, err)
+	}
+	second, fresh2, err := p.Submit(context.Background(), a, sig)
+	if err != nil {
+		t.Fatalf("second submit err: %v", err)
+	}
+	if fresh2 {
+		t.Fatal("expected fresh=false on duplicate submit")
+	}
+	if first.LeafIndex != second.LeafIndex {
+		t.Fatalf("idempotent leaf index: got %d want %d", second.LeafIndex, first.LeafIndex)
+	}
+	if !bytes.Equal(first.LeafHash, second.LeafHash) {
+		t.Fatal("idempotent leaf hash mismatch")
+	}
+	if tree.Size() != 1 {
+		t.Fatalf("tree grew on duplicate: size %d", tree.Size())
+	}
+}
+
+func TestSubmitIdempotentSameAgentNonceDifferentAction(t *testing.T) {
+	// Per spec: replay protection keys on (agent_id, nonce). Resubmitting
+	// the same nonce — even with a different action body — returns the
+	// originally recorded event without appending.
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, tree := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	nonce := randNonce(t)
+	a1 := makeAction("agent-1", now.UnixMilli(), nonce)
+	sig1, _ := signing.Sign(a1, priv)
+	first, _, err := p.Submit(context.Background(), a1, sig1)
+	if err != nil {
+		t.Fatalf("first submit: %v", err)
+	}
+
+	a2 := makeAction("agent-1", now.UnixMilli(), nonce)
+	a2.Target = "different-peer"
+	sig2, _ := signing.Sign(a2, priv)
+	second, fresh, err := p.Submit(context.Background(), a2, sig2)
+	if err != nil {
+		t.Fatalf("second submit: %v", err)
+	}
+	if fresh {
+		t.Fatal("expected nonce collision to be treated as duplicate")
+	}
+	if second.LeafIndex != first.LeafIndex {
+		t.Fatalf("expected cached event returned, got new index %d", second.LeafIndex)
+	}
+	if tree.Size() != 1 {
+		t.Fatalf("tree grew on nonce collision: size %d", tree.Size())
+	}
+}
+
+func TestSubmitUnknownAgent(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, _ := newPipelineAt(t, now)
+	// Register a different agent so we have keys to sign with.
+	_, priv := newAgent(t, store, "agent-x")
+
+	a := makeAction("agent-missing", now.UnixMilli(), randNonce(t))
+	sig, _ := signing.Sign(a, priv)
+
+	_, _, err := p.Submit(context.Background(), a, sig)
+	if !errors.Is(err, ErrUnknownAgent) {
+		t.Fatalf("err: got %v want ErrUnknownAgent", err)
+	}
+}
+
+func TestSubmitBadSignature(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, tree := newPipelineAt(t, now)
+	newAgent(t, store, "agent-1")
+
+	a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+	bad := make([]byte, ed25519.SignatureSize)
+	_, _, err := p.Submit(context.Background(), a, bad)
+	if !errors.Is(err, ErrInvalidSignature) {
+		t.Fatalf("err: got %v want ErrInvalidSignature", err)
+	}
+	if tree.Size() != 0 {
+		t.Fatalf("tree mutated on bad sig: size %d", tree.Size())
+	}
+}
+
+func TestSubmitTimestampSkew(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, _ := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	skewed := now.Add(action.MaxSkewMillis*time.Millisecond + time.Second).UnixMilli()
+	a := makeAction("agent-1", skewed, randNonce(t))
+	sig, _ := signing.Sign(a, priv)
+
+	_, _, err := p.Submit(context.Background(), a, sig)
+	if !errors.Is(err, ErrTimestampSkew) {
+		t.Fatalf("err: got %v want ErrTimestampSkew", err)
+	}
+}
+
+func TestSubmitSchemaVersionRejected(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, _ := newPipelineAt(t, now)
+	newAgent(t, store, "agent-1")
+
+	a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+	a.SchemaVersion = 99
+	// Cannot Sign (Validate will reject); craft a sig manually so the
+	// pipeline encounters the schema check, not a signing error.
+	sig := make([]byte, ed25519.SignatureSize)
+	_, _, err := p.Submit(context.Background(), a, sig)
+	if !errors.Is(err, ErrSchemaVersion) {
+		t.Fatalf("err: got %v want ErrSchemaVersion", err)
+	}
+}
+
+func TestSubscriberReceivesEvent(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, _ := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	ch, cancel := p.Subscribe()
+	defer cancel()
+
+	a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+	sig, _ := signing.Sign(a, priv)
+	if _, _, err := p.Submit(context.Background(), a, sig); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.LeafIndex != 0 {
+			t.Fatalf("event index: got %d", ev.LeafIndex)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber did not receive event")
+	}
+}
+
+func TestSlowSubscriberDoesNotBlock(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, _ := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	// Subscribe but never read. Pipeline must not block when the buffer fills.
+	_, cancel := p.Subscribe()
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 64; i++ {
+			a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+			sig, _ := signing.Sign(a, priv)
+			if _, _, err := p.Submit(context.Background(), a, sig); err != nil {
+				t.Errorf("submit %d: %v", i, err)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipeline blocked on slow subscriber")
+	}
+}
+
+func TestConcurrentSubmittersNoDoubleAppend(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, tree := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	const submitters = 16
+	a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+	sig, _ := signing.Sign(a, priv)
+
+	var wg sync.WaitGroup
+	wg.Add(submitters)
+	for i := 0; i < submitters; i++ {
+		go func() {
+			defer wg.Done()
+			if _, _, err := p.Submit(context.Background(), a, sig); err != nil {
+				t.Errorf("submit: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if tree.Size() != 1 {
+		t.Fatalf("expected exactly one append, got tree size %d", tree.Size())
+	}
+}
+
+func TestSubscribeCancelStopsDelivery(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, _ := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	ch, cancel := p.Subscribe()
+	cancel()
+
+	a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+	sig, _ := signing.Sign(a, priv)
+	if _, _, err := p.Submit(context.Background(), a, sig); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	// Channel should be closed; either the receive sees !ok promptly or we
+	// time out indicating it is still open (a bug).
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected channel closed after cancel")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("channel not closed after cancel")
+	}
+}
+
+func TestEventsSinceReplay(t *testing.T) {
+	now := time.UnixMilli(1_700_000_000_000)
+	p, store, _ := newPipelineAt(t, now)
+	_, priv := newAgent(t, store, "agent-1")
+
+	for i := 0; i < 3; i++ {
+		a := makeAction("agent-1", now.UnixMilli(), randNonce(t))
+		sig, _ := signing.Sign(a, priv)
+		if _, _, err := p.Submit(context.Background(), a, sig); err != nil {
+			t.Fatalf("submit: %v", err)
+		}
+	}
+
+	got := p.EventsSince(0)
+	if len(got) != 3 {
+		t.Fatalf("len: got %d want 3", len(got))
+	}
+	got = p.EventsSince(2)
+	if len(got) != 1 || got[0].LeafIndex != 2 {
+		t.Fatalf("since=2: %+v", got)
+	}
+}

--- a/go-key-service/internal/httpapi/handlers.go
+++ b/go-key-service/internal/httpapi/handlers.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
+	auditloghttp "github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog/http"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
 )
 
 type Server struct {
-	store  keystore.KeyStore
-	logger *slog.Logger
+	store    keystore.KeyStore
+	pipeline *auditlog.Pipeline
+	logger   *slog.Logger
 }
 
 func NewServer(store keystore.KeyStore, logger *slog.Logger) *Server {
@@ -24,6 +27,14 @@ func NewServer(store keystore.KeyStore, logger *slog.Logger) *Server {
 		logger = slog.Default()
 	}
 	return &Server{store: store, logger: logger}
+}
+
+// WithAuditPipeline mounts the audit-log endpoints on the same router as
+// the key endpoints. Pass nil to disable; it's optional so existing
+// callers (and tests) keep working.
+func (s *Server) WithAuditPipeline(p *auditlog.Pipeline) *Server {
+	s.pipeline = p
+	return s
 }
 
 func (s *Server) Router() http.Handler {
@@ -38,6 +49,9 @@ func (s *Server) Router() http.Handler {
 		r.Get("/{agentID}", s.handleGet)
 		r.Delete("/{agentID}", s.handleDelete)
 	})
+	if s.pipeline != nil {
+		auditloghttp.Mount(r, s.pipeline, s.logger)
+	}
 	return r
 }
 


### PR DESCRIPTION
## Summary

- New `internal/auditlog` package wires signature verification into Merkle append: `(action, sig)` → verify against the keystore's pubkey → `tree.Append(canonical(action) || sig)` → emit indexed `Event` to subscribers.
- Idempotent on `(agent_id, nonce)` within the 30s skew + 600s nonce window from `docs/schema.md`. Duplicates return the cached event without growing the tree.
- `POST /v1/audit/append` and SSE `GET /v1/audit/events?since=N` mounted on the keyserver next to `/v1/keys/...` so the dashboard (#19) can submit + tail.

Closes #11.

## Acceptance checklist

- [x] On verified signature → `merkle.append(hash(action || signature))` (`pipeline.go` `Submit`; leaf bytes are `canonical(action) || sig`, then RFC 6962 `HashLeaf` adds the 0x00 prefix)
- [x] Idempotent on duplicate `(agent_id, nonce)` (cache returns first event, tree size unchanged; covered by `TestSubmitIdempotent*` and `TestConcurrentSubmittersNoDoubleAppend`)
- [x] Emits indexed event for downstream consumers (subscriber channels + SSE stream with `since=` resume cursor)

## Test plan

- [x] `go test ./... -race -count=1` (in `go-key-service/`) — all packages green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean

## Notes for reviewers

- **Idempotency cache eviction**: lazy. Stale entries (older than skew + nonce window = 630s) are evicted on the next duplicate hit. No background sweeper goroutine — fine for the in-memory scope of this service. Documented at the `Pipeline` type.
- **Subscriber back-pressure**: each subscriber gets a small buffered channel (default 16). On full-buffer the append path drops for that subscriber rather than stalling. Slow consumers re-sync via `EventsSince(N)` after reconnect.
- **`events []*Event` retention**: unbounded for the lifetime of the process so SSE backfill works for any `since`. Comment in `pipeline.go` flags ring-buffer / external store as the next step before a long-running deployment.
- **Wiring**: `httpapi.Server.WithAuditPipeline(...)` is opt-in so existing keystore tests aren't perturbed. Audit endpoints are mounted onto the same chi router as `/v1/keys/*`.
- **HTTP error mapping**: bad sig → 401, unknown agent → 404, schema/skew → 422, malformed action → 400. Matches the existing `{error, message}` envelope.