### PR TITLE
feat(acl): UnauthorizedMetrics counter on top of #16 (#17)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,15 @@ between the live tree and on-chain commits to detect rewrites.
    signs it with the agent's private key (loaded from key-service or
    a local secret).
 3. `@requires_capability` checks the ACL by `agent_id`; missing
-   capability → `CapabilityError`.
+   capability → `CapabilityError`. For scoped enforcement,
+   `@requires_token` posts the active `Token` to the Go service's
+   `/v1/tokens/verify` endpoint (server-authoritative, fail-closed on
+   5xx) and only proceeds on `200 OK`. When an `UnauthorizedMetrics`
+   instance is bound to the decorator, every rejection — server-issued
+   (`expired`, `revoked`, `agent_mismatch`, `action_type_not_allowed`,
+   `target_not_allowed`) and client-side (missing context, unreachable
+   service) — increments the per-action-type counter the dashboard
+   reads as "unauthorized attempts".
 4. Co-approvers (or a quorum service) sign the same canonical bytes.
 5. Caller invokes `gate.execute(action, signatures, fn, ...)`. The gate
    verifies each signature, counts unique valid signers, compares to

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -86,6 +86,39 @@ def read_secret(name: str, *, agent_id: str) -> str:
 The agent id is read from `kwargs["agent_id"]` by default; pass
 `agent_id_arg="..."` to change the name.
 
+## Orchestrator metric: `UnauthorizedMetrics`
+
+`@requires_token` (the server-authoritative decorator from the
+preceding section) takes an optional `metrics: UnauthorizedMetrics`
+kwarg. Every rejection — whether the Go service returned
+`expired`/`revoked`/`agent_mismatch`/`action_type_not_allowed`/
+`target_not_allowed`, or the SDK rejected client-side
+(missing token context, unreachable service) — increments a counter
+keyed by the decorator's `action_type`. The decorator's
+authoritative decision is unchanged; metrics only observe.
+
+```python
+from cryptoagent import (
+    UnauthorizedMetrics, requires_token, signed_action, token_context,
+)
+
+metrics = UnauthorizedMetrics()
+
+@signed_action(agent_id="alice", action_type="transfer_funds",
+               target="vault/treasury", private_key=alice_priv)
+@requires_token(client, action_type="transfer_funds",
+                target="vault/treasury", metrics=metrics)
+def transfer(amount: int) -> str:
+    ...
+
+# After traffic has run:
+metrics.count("transfer_funds")    # int
+metrics.snapshot()                 # {action_type: count}
+```
+
+This counter is the success-metric input from the proposal — the
+dashboard reads it as "out-of-scope action rejections per type".
+
 ## Decorator: `@multi_sig` (and the `Gate`)
 
 For *critical* actions, the SDK enforces a t-of-n threshold of distinct

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -38,7 +38,7 @@ the underlying Ed25519 primitive.
 | T1 | Action attribution: actor unknown after the fact | Every action carries an Ed25519 signature over canonical bytes. `verify(action, sig, pub)` recovers the signer. |
 | T2 | Action replay (same signed bytes resubmitted) | `(agent_id, nonce)` cache + `±30 s` timestamp window per `docs/schema.md`. |
 | T3 | Cross-language signature drift | `docs/signing_vectors.json` fixture, asserted by Go and Python tests. |
-| T4 | Privilege escalation by an agent | `@requires_capability` against an `ACL`. |
+| T4 | Privilege escalation by an agent | `@requires_capability` against an `ACL` for coarse capability strings, or `@requires_token` against a server-issued, server-verified scoped token (`TokenClient` → Go `/v1/tokens/verify`) for `(agent_id, action_type, target)` + expiry + revocation; orchestrator side increments `UnauthorizedMetrics` per action_type for the success-metric counter. |
 | T5 | Single-agent unilateral action on critical operations | `Gate` enforces t-of-n distinct valid signers; `ThresholdNotMetError` on violation. |
 | T6 | Bypassing the gate by calling the function directly | `@gated` invariant decorator: direct call → `BypassError` and `gate.bypass_metrics()` increments. |
 | T7 | Silent rewrite of the audit log | RFC 6962 Merkle tree + consistency proofs. `Verifier.VerifyHistoricalRoot` flags any in-range tamper with a hex-bearing diagnostic. |

--- a/sdk-python/cryptoagent/__init__.py
+++ b/sdk-python/cryptoagent/__init__.py
@@ -2,7 +2,7 @@
 LangChain wrapper. See ``examples/langchain_agent.py`` for end-to-end
 usage."""
 
-from .acl import ACL, CapabilityError
+from .acl import ACL, CapabilityError, UnauthorizedMetrics
 from .action import (
     MAX_SKEW_MS,
     NONCE_HEX_LEN,
@@ -80,6 +80,7 @@ __all__ = [
     "TokenClient",
     "TokenError",
     "TokenServiceUnavailableError",
+    "UnauthorizedMetrics",
     "clear_token",
     "current_signed_action",
     "current_token",

--- a/sdk-python/cryptoagent/acl.py
+++ b/sdk-python/cryptoagent/acl.py
@@ -1,13 +1,22 @@
 """Capability-based access control for agents.
 
-An :class:`ACL` maps ``agent_id`` to a set of capability strings. A
-capability is a short, application-defined verb (e.g. ``"transfer_funds"``,
-``"read_secret"``); the trust layer never interprets the string, it only
-checks membership.
+Two pieces ship in this module:
+
+* :class:`ACL` — the original simple capability-string check used by
+  :func:`cryptoagent.decorators.requires_capability`. An agent either
+  has a capability string or it doesn't.
+* :class:`UnauthorizedMetrics` — per-action-type counter the
+  orchestrator hands to :func:`cryptoagent.decorators.requires_token`.
+  Server-side scope/expiry/revocation enforcement lives in
+  :mod:`cryptoagent.tokens` (issued and verified by the Go service);
+  this counter is the success-metric input the proposal calls for, so
+  the dashboard can read "out-of-scope action rejections per type".
 """
 
 from __future__ import annotations
 
+import threading
+from collections import Counter
 from collections.abc import Iterable
 
 
@@ -38,3 +47,44 @@ class ACL:
 
     def capabilities(self, agent_id: str) -> set[str]:
         return set(self._caps.get(agent_id, ()))
+
+
+class UnauthorizedMetrics:
+    """Per-action-type counter of rejected token verifications.
+
+    Wired into :func:`cryptoagent.decorators.requires_token` via the
+    ``metrics`` kwarg. Every rejection — server-issued ``TokenError``
+    (expired, revoked, agent_mismatch, action_type_not_allowed,
+    target_not_allowed, malformed, invalid_signature) and
+    client-side ``TokenError`` (missing context, unreachable
+    service) — increments the counter for the decorator's
+    ``action_type``. The decorator's authoritative decision (raise) is
+    independent of the counter; metrics never alter the outcome.
+
+    Thread-safe: the underlying ``Counter`` is mutated under a single
+    lock so the dashboard can read snapshots concurrently with active
+    agent traffic.
+    """
+
+    def __init__(self) -> None:
+        self._counts: Counter = Counter()
+        self._lock = threading.Lock()
+
+    def record(self, action_type: str) -> None:
+        with self._lock:
+            self._counts[action_type] += 1
+
+    def count(self, action_type: str | None = None) -> int:
+        with self._lock:
+            if action_type is None:
+                return sum(self._counts.values())
+            return int(self._counts[action_type])
+
+    def snapshot(self) -> dict[str, int]:
+        """Return a copy of the per-action-type counts."""
+        with self._lock:
+            return dict(self._counts)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counts.clear()

--- a/sdk-python/cryptoagent/decorators.py
+++ b/sdk-python/cryptoagent/decorators.py
@@ -18,7 +18,7 @@ import threading
 import time
 from collections.abc import Callable
 
-from .acl import ACL
+from .acl import ACL, UnauthorizedMetrics
 from .action import Action
 from .multisig import Gate
 from .signing import sign
@@ -119,6 +119,7 @@ def requires_token(
     *,
     action_type: str,
     target: str,
+    metrics: UnauthorizedMetrics | None = None,
 ) -> Callable:
     """Reject the call unless the active token authorizes
     ``(action_type, target)`` for the calling agent.
@@ -131,6 +132,11 @@ def requires_token(
 
     Must be applied *inside* ``@signed_action`` so the agent_id is
     available.
+
+    If ``metrics`` is supplied, every rejection increments the
+    per-action-type unauthorized counter — the success-metric input the
+    proposal asks for. Decisions are still authoritative even when
+    ``metrics`` is ``None``.
     """
 
     def deco(fn: Callable) -> Callable:
@@ -138,17 +144,26 @@ def requires_token(
         def wrapper(*args, **kwargs):
             ctx = current_signed_action()
             if ctx is None:
+                if metrics is not None:
+                    metrics.record(action_type)
                 raise TokenError("@requires_token must be inside @signed_action")
             action, _ = ctx
             token = current_token()
             if token is None:
+                if metrics is not None:
+                    metrics.record(action_type)
                 raise TokenError("no active token in context")
-            client.verify(
-                token,
-                action_type=action_type,
-                target=target,
-                agent_id=action.agent_id,
-            )
+            try:
+                client.verify(
+                    token,
+                    action_type=action_type,
+                    target=target,
+                    agent_id=action.agent_id,
+                )
+            except TokenError:
+                if metrics is not None:
+                    metrics.record(action_type)
+                raise
             return fn(*args, **kwargs)
 
         return wrapper

--- a/sdk-python/tests/conftest.py
+++ b/sdk-python/tests/conftest.py
@@ -1,0 +1,108 @@
+"""Shared pytest fixtures.
+
+`fake_service` spins up a stdlib `http.server` on an ephemeral port that
+records every call and replays a queued response — the same shape used
+by `test_tokens.py` for the TokenClient. Lives here (not inside a test
+file) so multiple test modules can pick it up via pytest's auto-discovery
+without creating import cycles.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+
+class _FakeService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses: list[tuple[int, dict[str, Any] | None]] = []
+
+    def queue(self, status: int, body: dict[str, Any] | None) -> None:
+        self.responses.append((status, body))
+
+    def pop(self) -> tuple[int, dict[str, Any] | None]:
+        if not self.responses:
+            return 200, {"ok": True}
+        return self.responses.pop(0)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    service: _FakeService  # injected by factory
+
+    def log_message(self, *args, **kwargs) -> None:  # silence test noise
+        pass
+
+    def _read(self) -> dict[str, Any] | None:
+        length = int(self.headers.get("Content-Length") or "0")
+        if length == 0:
+            return None
+        raw = self.rfile.read(length)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+
+    def _serve(self, method: str) -> None:
+        body = self._read()
+        self.service.calls.append({"method": method, "path": self.path, "body": body})
+        status, payload = self.service.pop()
+        self.send_response(status)
+        if payload is None:
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        else:
+            data = json.dumps(payload).encode("utf-8")
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+    def do_GET(self) -> None:  # noqa: N802 — stdlib API name
+        self._serve("GET")
+
+    def do_POST(self) -> None:  # noqa: N802 — stdlib API name
+        self._serve("POST")
+
+
+@pytest.fixture
+def fake_service() -> Iterator[tuple[_FakeService, str]]:
+    svc = _FakeService()
+    handler_cls = type("H", (_Handler,), {"service": svc})
+    httpd = HTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield svc, f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def _claims_payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "token_id": "tok-1",
+        "agent_id": "agent-a",
+        "action_types": ["transfer"],
+        "targets": ["acct:1"],
+        "issued_at": 1_700_000_000,
+        "expires_at": 1_700_003_600,
+    }
+    base.update(overrides)
+    return base
+
+
+def _issue_response(claims: dict[str, Any] | None = None) -> dict[str, Any]:
+    claims = claims or _claims_payload()
+    return {
+        "token_id": claims["token_id"],
+        "claims_json": json.dumps(claims),
+        "signature_hex": "ab" * 64,
+    }

--- a/sdk-python/tests/test_acl.py
+++ b/sdk-python/tests/test_acl.py
@@ -1,6 +1,23 @@
 import pytest
 
-from cryptoagent.acl import ACL, CapabilityError
+from cryptoagent import (
+    ACL,
+    CapabilityError,
+    Token,
+    TokenClient,
+    TokenError,
+    UnauthorizedMetrics,
+    requires_token,
+    signed_action,
+    token_context,
+)
+from cryptoagent.signing import generate_keypair
+
+# Re-use the in-process fake server fixture from conftest so the
+# decorator path is exercised against the same wire shape Adarsh's
+# TokenClient was tested with — no new HTTP scaffolding here. The
+# `fake_service` fixture is auto-discovered by pytest.
+from tests.conftest import _issue_response
 
 
 def test_grant_and_check():
@@ -36,3 +53,151 @@ def test_capabilities_snapshot_is_copy():
     snap = acl.capabilities("a")
     snap.add("y")
     assert acl.capabilities("a") == {"x"}
+
+
+# ---------------------------------------------------------------------------
+# UnauthorizedMetrics — issue #17 success-metric counter
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_record_and_count():
+    m = UnauthorizedMetrics()
+    m.record("transfer_funds")
+    m.record("transfer_funds")
+    m.record("delete")
+    assert m.count("transfer_funds") == 2
+    assert m.count("delete") == 1
+    assert m.count() == 3
+
+
+def test_metrics_snapshot_is_copy():
+    m = UnauthorizedMetrics()
+    m.record("transfer_funds")
+    snap = m.snapshot()
+    snap["transfer_funds"] = 99
+    assert m.count("transfer_funds") == 1
+
+
+def test_metrics_reset():
+    m = UnauthorizedMetrics()
+    m.record("x")
+    m.reset()
+    assert m.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Decorator integration: server-side rejection bumps the local counter.
+# Covers the issue #17 acceptance bullets end-to-end against the real
+# TokenClient with a stubbed HTTP backend (no network).
+# ---------------------------------------------------------------------------
+
+
+def _wrap(client: TokenClient, metrics: UnauthorizedMetrics, *, target: str = "acct:1"):
+    _, priv = generate_keypair()
+
+    @signed_action(
+        agent_id="agent-a",
+        action_type="transfer",
+        target=target,
+        private_key=priv,
+        clock=lambda: 1_700_000_000_000,
+    )
+    @requires_token(client, action_type="transfer", target=target, metrics=metrics)
+    def call() -> str:
+        return "ran"
+
+    return call
+
+
+def test_in_scope_allowed_no_metric_increment(fake_service):
+    svc, base = fake_service
+    svc.queue(200, {"ok": True, "token_id": "tok-1"})
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _wrap(client, metrics)
+    with token_context(Token.from_response(_issue_response())):
+        assert call() == "ran"
+    assert metrics.count() == 0
+
+
+def test_out_of_scope_action_type_rejected_and_counted(fake_service):
+    svc, base = fake_service
+    svc.queue(403, {"error": "action_type_not_allowed", "message": "nope"})
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _wrap(client, metrics)
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError):
+            call()
+    assert metrics.count("transfer") == 1
+    assert metrics.count() == 1
+
+
+def test_out_of_scope_target_rejected_and_counted(fake_service):
+    svc, base = fake_service
+    svc.queue(403, {"error": "target_not_allowed", "message": "nope"})
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _wrap(client, metrics)
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError):
+            call()
+    assert metrics.count("transfer") == 1
+
+
+def test_expired_rejected_and_counted(fake_service):
+    svc, base = fake_service
+    svc.queue(403, {"error": "expired", "message": "expired"})
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _wrap(client, metrics)
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError) as exc:
+            call()
+    assert exc.value.error_code == "expired"
+    assert metrics.count("transfer") == 1
+
+
+def test_revoked_rejected_and_counted(fake_service):
+    svc, base = fake_service
+    svc.queue(403, {"error": "revoked", "message": "revoked"})
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _wrap(client, metrics)
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError):
+            call()
+    assert metrics.count("transfer") == 1
+
+
+def test_missing_token_context_counted(fake_service):
+    _, base = fake_service
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _wrap(client, metrics)
+    # No token_context() — the decorator must reject and count.
+    with pytest.raises(TokenError):
+        call()
+    assert metrics.count("transfer") == 1
+
+
+def test_metrics_optional_decorator_works_without_it(fake_service):
+    svc, base = fake_service
+    svc.queue(403, {"error": "expired", "message": "expired"})
+    client = TokenClient(base)
+    _, priv = generate_keypair()
+
+    @signed_action(
+        agent_id="agent-a",
+        action_type="transfer",
+        target="acct:1",
+        private_key=priv,
+        clock=lambda: 1_700_000_000_000,
+    )
+    @requires_token(client, action_type="transfer", target="acct:1")
+    def call() -> str:
+        return "ran"
+
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError):
+            call()

--- a/sdk-python/tests/test_tokens.py
+++ b/sdk-python/tests/test_tokens.py
@@ -7,10 +7,7 @@ the wire shape too.
 
 from __future__ import annotations
 
-import json
-import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
 
 import pytest
 
@@ -27,102 +24,7 @@ from cryptoagent.tokens import (
     set_token,
     token_context,
 )
-
-# ---------- fixtures: in-process fake service ---------------------------
-
-
-class _FakeService:
-    """Drives a per-test HTTP server that replays canned responses."""
-
-    def __init__(self) -> None:
-        self.calls: list[dict[str, Any]] = []
-        self.responses: list[tuple[int, dict[str, Any] | None]] = []
-
-    def queue(self, status: int, body: dict[str, Any] | None) -> None:
-        self.responses.append((status, body))
-
-    def pop(self) -> tuple[int, dict[str, Any] | None]:
-        if not self.responses:
-            return 200, {"ok": True}
-        return self.responses.pop(0)
-
-
-class _Handler(BaseHTTPRequestHandler):
-    service: _FakeService  # set by factory
-
-    def log_message(self, *args, **kwargs) -> None:  # silence test noise
-        pass
-
-    def _read(self) -> dict[str, Any] | None:
-        length = int(self.headers.get("Content-Length") or "0")
-        if length == 0:
-            return None
-        raw = self.rfile.read(length)
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError:
-            return None
-
-    def _serve(self, method: str) -> None:
-        body = self._read()
-        self.service.calls.append({"method": method, "path": self.path, "body": body})
-        status, payload = self.service.pop()
-        self.send_response(status)
-        if payload is None:
-            self.send_header("Content-Length", "0")
-            self.end_headers()
-        else:
-            data = json.dumps(payload).encode("utf-8")
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(data)))
-            self.end_headers()
-            self.wfile.write(data)
-
-    def do_POST(self) -> None:  # noqa: N802 — http.server contract
-        self._serve("POST")
-
-    def do_GET(self) -> None:  # noqa: N802
-        self._serve("GET")
-
-
-@pytest.fixture
-def fake_service():
-    svc = _FakeService()
-
-    handler_cls = type("H", (_Handler,), {"service": svc})
-    httpd = HTTPServer(("127.0.0.1", 0), handler_cls)
-    port = httpd.server_address[1]
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield svc, f"http://127.0.0.1:{port}"
-    finally:
-        httpd.shutdown()
-        httpd.server_close()
-        thread.join(timeout=2)
-
-
-def _claims_payload(**overrides: Any) -> dict[str, Any]:
-    base = {
-        "token_id": "tok-1",
-        "agent_id": "agent-a",
-        "action_types": ["transfer"],
-        "targets": ["acct:1"],
-        "issued_at": 1_700_000_000,
-        "expires_at": 1_700_003_600,
-    }
-    base.update(overrides)
-    return base
-
-
-def _issue_response(claims: dict[str, Any] | None = None) -> dict[str, Any]:
-    claims = claims or _claims_payload()
-    return {
-        "token_id": claims["token_id"],
-        "claims_json": json.dumps(claims),
-        "signature_hex": "ab" * 64,
-    }
-
+from tests.conftest import _claims_payload, _issue_response
 
 # ---------- Token dataclass ---------------------------------------------
 


### PR DESCRIPTION
## Summary

Builds on top of #16's server-authoritative `@requires_token`:

- New `UnauthorizedMetrics` in `acl.py` — thread-safe per-action-type counter (`record`, `count`, `snapshot`, `reset`).
- `@requires_token` now accepts an optional `metrics: UnauthorizedMetrics`. Every rejection (server-issued *and* client-side fail-closed paths) increments `metrics.record(action_type)`. Authoritative decision is unchanged.
- Shared HTTP fixture moved to `tests/conftest.py` so this test file and `test_tokens.py` both pick it up via pytest auto-discovery.

Closes #17.

## Acceptance checklist

- [x] Reject any action whose `(agent_id, action_type, target)` is not covered by the token — handled by #16's server-side verify; this PR observes the rejection.
- [x] Unauthorized attempts increment a counter — `UnauthorizedMetrics.record(action_type)` from inside `requires_token`'s `except TokenError` branch (and on missing-context branches).
- [x] Tests: in-scope allowed (no increment), out-of-scope `action_type` rejected & counted, out-of-scope `target` rejected & counted, expired rejected & counted, revoked rejected & counted, missing token context rejected & counted, decorator works without `metrics`.

## Test plan

- [x] `pytest -q` (in `sdk-python/`) — 95 passed, 1 skipped
- [x] `ruff check cryptoagent tests` clean
- [x] `ruff format --check cryptoagent tests` clean

## Notes for reviewers

- **Why an additive `metrics=` kwarg, not a separate decorator.** Wrapping #16's decorator would require either reimplementing the verify path or a closure dance to extract the chosen `error_code`. Threading the optional metrics into the existing decorator keeps a single source of truth for "did this attempt clear the gate." Default is `None`, so existing callers see no behavior change.
- **What counts as unauthorized.** Server-side: every non-200 from `/v1/tokens/verify` (expired, revoked, agent_mismatch, action_type_not_allowed, target_not_allowed, invalid_signature, malformed_token). Client-side: missing `@signed_action` context, missing `token_context()`, unreachable service (5xx / network error). The latter is intentional — fail-closed events are still "authorized requests blocked," which is what the dashboard wants to see when something is misconfigured.
- **Originally proposed `CapabilityToken`/`CapabilityRegistry` were dropped** in the rebase: #16 ships server-issued tokens with the same shape (`token_id`, `agent_id`, `action_types`, `targets`, `expires_at`) and a server-authoritative verify path. Re-introducing a parallel local store would split the source of truth.
- **`conftest.py`** holds `_FakeService`, `_Handler`, `fake_service` fixture, and `_claims_payload` / `_issue_response` helpers. `test_tokens.py` no longer defines them — re-runs of `pytest tests/test_tokens.py` still pass standalone.