### PR TITLE
scoped capability tokens (#16)

### DIFF
--- a/go-key-service/cmd/keyserver/main.go
+++ b/go-key-service/cmd/keyserver/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/capability"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/config"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/httpapi"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
@@ -32,9 +33,17 @@ func main() {
 	store := keystore.NewMemory()
 	tree := merkle.New()
 	pipeline := auditlog.New(tree, store)
+	capSvc, err := capability.NewService(store, capability.Options{Logger: logger})
+	if err != nil {
+		logger.Error("capability", "err", err)
+		os.Exit(1)
+	}
 	srv := &http.Server{
-		Addr:              cfg.Addr,
-		Handler:           httpapi.NewServer(store, logger).WithAuditPipeline(pipeline).Router(),
+		Addr: cfg.Addr,
+		Handler: httpapi.NewServer(store, logger).
+			WithAuditPipeline(pipeline).
+			WithCapability(capSvc).
+			Router(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/go-key-service/go.mod
+++ b/go-key-service/go.mod
@@ -3,3 +3,5 @@ module github.com/knhn1004/CryptoAgent/go-key-service
 go 1.25.0
 
 require github.com/go-chi/chi/v5 v5.2.5
+
+require github.com/google/uuid v1.6.0

--- a/go-key-service/go.sum
+++ b/go-key-service/go.sum
@@ -1,2 +1,4 @@
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/go-key-service/internal/capability/http/handler.go
+++ b/go-key-service/internal/capability/http/handler.go
@@ -1,0 +1,181 @@
+// Package capabilityhttp exposes the capability Service over JSON HTTP.
+package capabilityhttp
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/capability"
+)
+
+// Mount attaches the capability endpoints onto an existing chi.Router.
+func Mount(r chi.Router, svc *capability.Service, logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &handler{svc: svc, logger: logger}
+	r.Route("/v1/tokens", func(r chi.Router) {
+		r.Post("/", h.issue)
+		r.Post("/verify", h.verify)
+		r.Post("/{tokenID}/revoke", h.revoke)
+		r.Get("/signing-pubkey", h.signingPubkey)
+	})
+}
+
+// Handler returns a standalone http.Handler — useful for tests.
+func Handler(svc *capability.Service, logger *slog.Logger) http.Handler {
+	r := chi.NewRouter()
+	Mount(r, svc, logger)
+	return r
+}
+
+type handler struct {
+	svc    *capability.Service
+	logger *slog.Logger
+}
+
+type issueRequest struct {
+	AgentID     string   `json:"agent_id"`
+	ActionTypes []string `json:"action_types"`
+	Targets     []string `json:"targets"`
+	TTLSeconds  int64    `json:"ttl_seconds"`
+}
+
+type issueResponse struct {
+	TokenID      string `json:"token_id"`
+	ClaimsJSON   string `json:"claims_json"`
+	SignatureHex string `json:"signature_hex"`
+}
+
+func (h *handler) issue(w http.ResponseWriter, r *http.Request) {
+	var req issueRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+	if req.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "agent_id is required")
+		return
+	}
+	if req.ActionTypes == nil {
+		writeError(w, http.StatusBadRequest, "missing_field", "action_types is required")
+		return
+	}
+	if req.Targets == nil {
+		writeError(w, http.StatusBadRequest, "missing_field", "targets is required")
+		return
+	}
+	tok, claims, sig, err := h.svc.Issue(r.Context(), capability.IssueRequest{
+		AgentID:     req.AgentID,
+		ActionTypes: req.ActionTypes,
+		Targets:     req.Targets,
+		TTLSeconds:  req.TTLSeconds,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, capability.ErrInvalidTTL):
+			writeError(w, http.StatusBadRequest, "invalid_ttl", err.Error())
+		case errors.Is(err, capability.ErrUnknownAgent):
+			writeError(w, http.StatusNotFound, "unknown_agent", err.Error())
+		default:
+			h.logger.Error("token issue", "err", err)
+			writeError(w, http.StatusInternalServerError, "internal", "internal error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusCreated, issueResponse{
+		TokenID:      tok.TokenID,
+		ClaimsJSON:   string(claims),
+		SignatureHex: hex.EncodeToString(sig),
+	})
+}
+
+type verifyRequest struct {
+	ClaimsJSON   string `json:"claims_json"`
+	SignatureHex string `json:"signature_hex"`
+	AgentID      string `json:"agent_id"`
+	ActionType   string `json:"action_type"`
+	Target       string `json:"target"`
+}
+
+type verifyResponse struct {
+	OK      bool   `json:"ok"`
+	TokenID string `json:"token_id"`
+}
+
+func (h *handler) verify(w http.ResponseWriter, r *http.Request) {
+	var req verifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+	if req.ClaimsJSON == "" || req.SignatureHex == "" || req.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "claims_json, signature_hex, agent_id are required")
+		return
+	}
+	sig, err := hex.DecodeString(req.SignatureHex)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_signature_hex", err.Error())
+		return
+	}
+	tok, err := h.svc.Verify(r.Context(), capability.VerifyRequest{
+		ClaimsJSON: []byte(req.ClaimsJSON),
+		Signature:  sig,
+		AgentID:    req.AgentID,
+		ActionType: req.ActionType,
+		Target:     req.Target,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, capability.ErrMalformedToken):
+			writeError(w, http.StatusBadRequest, "malformed_token", err.Error())
+		case errors.Is(err, capability.ErrInvalidSignature):
+			writeError(w, http.StatusUnauthorized, "invalid_signature", err.Error())
+		case errors.Is(err, capability.ErrExpired):
+			writeError(w, http.StatusForbidden, "expired", err.Error())
+		case errors.Is(err, capability.ErrRevoked):
+			writeError(w, http.StatusForbidden, "revoked", err.Error())
+		case errors.Is(err, capability.ErrAgentMismatch):
+			writeError(w, http.StatusForbidden, "agent_mismatch", err.Error())
+		case errors.Is(err, capability.ErrActionTypeNotAllowed):
+			writeError(w, http.StatusForbidden, "action_type_not_allowed", err.Error())
+		case errors.Is(err, capability.ErrTargetNotAllowed):
+			writeError(w, http.StatusForbidden, "target_not_allowed", err.Error())
+		default:
+			h.logger.Error("token verify", "err", err)
+			writeError(w, http.StatusInternalServerError, "internal", "internal error")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, verifyResponse{OK: true, TokenID: tok.TokenID})
+}
+
+func (h *handler) revoke(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "tokenID")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "tokenID path param required")
+		return
+	}
+	h.svc.Revoke(r.Context(), id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handler) signingPubkey(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"public_key_hex": hex.EncodeToString(h.svc.SigningPublicKey()),
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, map[string]string{"error": code, "message": msg})
+}

--- a/go-key-service/internal/capability/http/handler_test.go
+++ b/go-key-service/internal/capability/http/handler_test.go
@@ -1,0 +1,275 @@
+package capabilityhttp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/capability"
+	capabilityhttp "github.com/knhn1004/CryptoAgent/go-key-service/internal/capability/http"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+)
+
+func newServer(t *testing.T, now time.Time) (*capability.Service, http.Handler) {
+	t.Helper()
+	store := keystore.NewMemory()
+	if _, err := store.Create(context.Background(), "agent-1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	svc, err := capability.NewService(store, capability.Options{
+		Clock:  func() time.Time { return now },
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, capabilityhttp.Handler(svc, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func do(t *testing.T, h http.Handler, method, path string, body any) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	out := map[string]any{}
+	if rec.Body.Len() > 0 && rec.Header().Get("Content-Type") == "application/json" {
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("unmarshal response: %v\nbody: %s", err, rec.Body.String())
+		}
+	}
+	return rec, out
+}
+
+func TestIssueHandlerHappyPath(t *testing.T) {
+	_, h := newServer(t, time.Unix(1_700_000_000, 0))
+	rec, out := do(t, h, "POST", "/v1/tokens", map[string]any{
+		"agent_id":     "agent-1",
+		"action_types": []string{"transfer"},
+		"targets":      []string{"acct:1"},
+		"ttl_seconds":  3600,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d want 201, body: %s", rec.Code, rec.Body.String())
+	}
+	for _, k := range []string{"token_id", "claims_json", "signature_hex"} {
+		if _, ok := out[k]; !ok {
+			t.Fatalf("missing field %q in response: %v", k, out)
+		}
+	}
+}
+
+func TestIssueHandlerErrors(t *testing.T) {
+	_, h := newServer(t, time.Unix(1_700_000_000, 0))
+
+	cases := []struct {
+		name   string
+		body   any
+		status int
+		code   string
+	}{
+		{"unparseable body", "not-json", http.StatusBadRequest, "invalid_json"},
+		{"missing agent_id", map[string]any{"action_types": []string{"x"}, "targets": []string{"y"}, "ttl_seconds": 60}, http.StatusBadRequest, "missing_field"},
+		{"missing action_types", map[string]any{"agent_id": "agent-1", "targets": []string{"y"}, "ttl_seconds": 60}, http.StatusBadRequest, "missing_field"},
+		{"missing targets", map[string]any{"agent_id": "agent-1", "action_types": []string{"x"}, "ttl_seconds": 60}, http.StatusBadRequest, "missing_field"},
+		{"invalid ttl", map[string]any{"agent_id": "agent-1", "action_types": []string{"x"}, "targets": []string{"y"}, "ttl_seconds": 0}, http.StatusBadRequest, "invalid_ttl"},
+		{"unknown agent", map[string]any{"agent_id": "ghost", "action_types": []string{"x"}, "targets": []string{"y"}, "ttl_seconds": 60}, http.StatusNotFound, "unknown_agent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, out := do(t, h, "POST", "/v1/tokens", tc.body)
+			if rec.Code != tc.status {
+				t.Fatalf("status: got %d want %d", rec.Code, tc.status)
+			}
+			if out["error"] != tc.code {
+				t.Fatalf("error: got %v want %q", out["error"], tc.code)
+			}
+		})
+	}
+}
+
+func issueTok(t *testing.T, h http.Handler, agent string, types, targets []string, ttl int64) (string, string, string) {
+	t.Helper()
+	rec, out := do(t, h, "POST", "/v1/tokens", map[string]any{
+		"agent_id":     agent,
+		"action_types": types,
+		"targets":      targets,
+		"ttl_seconds":  ttl,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("issue: %d %s", rec.Code, rec.Body.String())
+	}
+	return out["token_id"].(string), out["claims_json"].(string), out["signature_hex"].(string)
+}
+
+func TestVerifyHandlerHappyPath(t *testing.T) {
+	_, h := newServer(t, time.Unix(1_700_000_000, 0))
+	id, claims, sig := issueTok(t, h, "agent-1", []string{"transfer"}, []string{"acct:1"}, 3600)
+	rec, out := do(t, h, "POST", "/v1/tokens/verify", map[string]any{
+		"claims_json":   claims,
+		"signature_hex": sig,
+		"agent_id":      "agent-1",
+		"action_type":   "transfer",
+		"target":        "acct:1",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body: %s", rec.Code, rec.Body.String())
+	}
+	if out["ok"] != true || out["token_id"] != id {
+		t.Fatalf("response: %v", out)
+	}
+}
+
+func TestVerifyHandlerErrorsMapping(t *testing.T) {
+	svc, h := newServer(t, time.Unix(1_700_000_000, 0))
+	_, claims, sig := issueTok(t, h, "agent-1", []string{"transfer"}, []string{"acct:1"}, 3600)
+
+	cases := []struct {
+		name    string
+		mutate  func(req map[string]any) // mutates a base verify request
+		status  int
+		errCode string
+		// optional: change svc state before request
+		setup func()
+	}{
+		{
+			name:    "invalid_signature_hex",
+			mutate:  func(r map[string]any) { r["signature_hex"] = "not-hex" },
+			status:  http.StatusBadRequest,
+			errCode: "invalid_signature_hex",
+		},
+		{
+			name:    "missing_field",
+			mutate:  func(r map[string]any) { delete(r, "agent_id") },
+			status:  http.StatusBadRequest,
+			errCode: "missing_field",
+		},
+		{
+			name:    "malformed_token",
+			mutate:  func(r map[string]any) { r["claims_json"] = "not-json" },
+			status:  http.StatusBadRequest,
+			errCode: "malformed_token",
+		},
+		{
+			name:    "agent_mismatch",
+			mutate:  func(r map[string]any) { r["agent_id"] = "other" },
+			status:  http.StatusForbidden,
+			errCode: "agent_mismatch",
+		},
+		{
+			name:    "action_type_not_allowed",
+			mutate:  func(r map[string]any) { r["action_type"] = "withdraw" },
+			status:  http.StatusForbidden,
+			errCode: "action_type_not_allowed",
+		},
+		{
+			name:    "target_not_allowed",
+			mutate:  func(r map[string]any) { r["target"] = "acct:other" },
+			status:  http.StatusForbidden,
+			errCode: "target_not_allowed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup()
+			}
+			req := map[string]any{
+				"claims_json":   claims,
+				"signature_hex": sig,
+				"agent_id":      "agent-1",
+				"action_type":   "transfer",
+				"target":        "acct:1",
+			}
+			tc.mutate(req)
+			rec, out := do(t, h, "POST", "/v1/tokens/verify", req)
+			if rec.Code != tc.status {
+				t.Fatalf("status: got %d want %d", rec.Code, tc.status)
+			}
+			if out["error"] != tc.errCode {
+				t.Fatalf("error: got %v want %q", out["error"], tc.errCode)
+			}
+		})
+	}
+
+	_ = svc
+}
+
+// Expired/revoked need clock control, so they get their own server with a
+// mutable clock variable closed over.
+func TestVerifyExpiredAndRevokedFlows(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	store := keystore.NewMemory()
+	if _, err := store.Create(context.Background(), "agent-1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	clock := now
+	svc, err := capability.NewService(store, capability.Options{
+		Clock:  func() time.Time { return clock },
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("svc: %v", err)
+	}
+	h := capabilityhttp.Handler(svc, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	id, claims, sig := issueTok(t, h, "agent-1", []string{"transfer"}, []string{"acct:1"}, 60)
+
+	// revoked
+	rec, _ := do(t, h, "POST", "/v1/tokens/"+id+"/revoke", nil)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("revoke status: %d", rec.Code)
+	}
+	rec, out := do(t, h, "POST", "/v1/tokens/verify", map[string]any{
+		"claims_json": claims, "signature_hex": sig,
+		"agent_id": "agent-1", "action_type": "transfer", "target": "acct:1",
+	})
+	if rec.Code != http.StatusForbidden || out["error"] != "revoked" {
+		t.Fatalf("revoked path: %d %v", rec.Code, out)
+	}
+
+	// expired (use a fresh token, then advance clock)
+	id2, claims2, sig2 := issueTok(t, h, "agent-1", []string{"transfer"}, []string{"acct:1"}, 60)
+	_ = id2
+	clock = time.Unix(now.Unix()+60, 0)
+	rec, out = do(t, h, "POST", "/v1/tokens/verify", map[string]any{
+		"claims_json": claims2, "signature_hex": sig2,
+		"agent_id": "agent-1", "action_type": "transfer", "target": "acct:1",
+	})
+	if rec.Code != http.StatusForbidden || out["error"] != "expired" {
+		t.Fatalf("expired path: %d %v", rec.Code, out)
+	}
+}
+
+func TestRevokeIdempotent(t *testing.T) {
+	_, h := newServer(t, time.Unix(1_700_000_000, 0))
+	rec, _ := do(t, h, "POST", "/v1/tokens/never-issued/revoke", nil)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("revoke unknown: %d", rec.Code)
+	}
+}
+
+func TestSigningPubkey(t *testing.T) {
+	_, h := newServer(t, time.Unix(1_700_000_000, 0))
+	rec, out := do(t, h, "GET", "/v1/tokens/signing-pubkey", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	v, _ := out["public_key_hex"].(string)
+	if len(v) != 64 { // 32 bytes hex-encoded
+		t.Fatalf("pubkey hex length: %d (%q)", len(v), v)
+	}
+}

--- a/go-key-service/internal/capability/revocation.go
+++ b/go-key-service/internal/capability/revocation.go
@@ -1,0 +1,32 @@
+package capability
+
+import "sync"
+
+// RevocationStore tracks the set of revoked token ids.
+type RevocationStore interface {
+	Revoke(tokenID string)
+	IsRevoked(tokenID string) bool
+}
+
+// MemoryStore is an in-memory RevocationStore safe for concurrent use.
+type MemoryStore struct {
+	mu  sync.RWMutex
+	ids map[string]struct{}
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{ids: make(map[string]struct{})}
+}
+
+func (m *MemoryStore) Revoke(tokenID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ids[tokenID] = struct{}{}
+}
+
+func (m *MemoryStore) IsRevoked(tokenID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.ids[tokenID]
+	return ok
+}

--- a/go-key-service/internal/capability/revocation_test.go
+++ b/go-key-service/internal/capability/revocation_test.go
@@ -1,0 +1,22 @@
+package capability
+
+import "testing"
+
+func TestMemoryStoreRevokeAndQuery(t *testing.T) {
+	s := NewMemoryStore()
+	if s.IsRevoked("a") {
+		t.Fatalf("fresh store reports revoked")
+	}
+	s.Revoke("a")
+	if !s.IsRevoked("a") {
+		t.Fatalf("Revoke did not stick")
+	}
+	// Idempotent.
+	s.Revoke("a")
+	if !s.IsRevoked("a") {
+		t.Fatalf("second Revoke broke state")
+	}
+	if s.IsRevoked("b") {
+		t.Fatalf("unrelated id reported revoked")
+	}
+}

--- a/go-key-service/internal/capability/service.go
+++ b/go-key-service/internal/capability/service.go
@@ -1,0 +1,179 @@
+package capability
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+)
+
+// Clock returns the current time. Injectable so tests can pin it.
+type Clock func() time.Time
+
+// Service issues, verifies, and revokes capability tokens. The service
+// owns its own Ed25519 signing key (in-memory; rotated on restart) and
+// consults the keystore to confirm agents exist at issuance time.
+type Service struct {
+	store      keystore.KeyStore
+	revocation RevocationStore
+	signPriv   ed25519.PrivateKey
+	signPub    ed25519.PublicKey
+	clock      Clock
+	logger     *slog.Logger
+}
+
+// Options configures a Service. Zero values get sensible defaults.
+type Options struct {
+	Revocation RevocationStore
+	Clock      Clock
+	Logger     *slog.Logger
+	// SigningKey lets callers inject a key (e.g. for tests). If nil, a
+	// fresh keypair is generated.
+	SigningPrivateKey ed25519.PrivateKey
+}
+
+// NewService constructs a Service. The keystore is required; everything
+// else has a sensible default.
+func NewService(store keystore.KeyStore, opts Options) (*Service, error) {
+	if store == nil {
+		return nil, errors.New("capability: keystore is required")
+	}
+	rev := opts.Revocation
+	if rev == nil {
+		rev = NewMemoryStore()
+	}
+	clock := opts.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	priv := opts.SigningPrivateKey
+	var pub ed25519.PublicKey
+	if priv == nil {
+		var err error
+		pub, priv, err = ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if len(priv) != ed25519.PrivateKeySize {
+			return nil, errors.New("capability: signing key must be ed25519.PrivateKeySize")
+		}
+		pub = priv.Public().(ed25519.PublicKey)
+	}
+	return &Service{
+		store:      store,
+		revocation: rev,
+		signPriv:   priv,
+		signPub:    pub,
+		clock:      clock,
+		logger:     logger,
+	}, nil
+}
+
+// IssueRequest is the input to Service.Issue.
+type IssueRequest struct {
+	AgentID     string
+	ActionTypes []string
+	Targets     []string
+	TTLSeconds  int64
+}
+
+// Issue mints a fresh token for the agent. It returns the token, the
+// canonical claim bytes (exactly what was signed) and the detached
+// signature. Returns ErrUnknownAgent if the agent is not in the
+// keystore, ErrInvalidTTL if ttl_seconds <= 0.
+func (s *Service) Issue(ctx context.Context, req IssueRequest) (*Token, []byte, []byte, error) {
+	if req.TTLSeconds <= 0 {
+		return nil, nil, nil, ErrInvalidTTL
+	}
+	if _, _, err := s.store.Get(ctx, req.AgentID); err != nil {
+		if errors.Is(err, keystore.ErrNotFound) {
+			return nil, nil, nil, ErrUnknownAgent
+		}
+		return nil, nil, nil, err
+	}
+	now := s.clock().Unix()
+	tok := &Token{
+		TokenID:     uuid.NewString(),
+		AgentID:     req.AgentID,
+		ActionTypes: append([]string(nil), req.ActionTypes...),
+		Targets:     append([]string(nil), req.Targets...),
+		IssuedAt:    now,
+		ExpiresAt:   now + req.TTLSeconds,
+	}
+	canonical, err := tok.Canonical()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	sig := ed25519.Sign(s.signPriv, canonical)
+	s.logger.Info("token issued",
+		"token_id", tok.TokenID,
+		"agent_id", tok.AgentID,
+		"expires_at", tok.ExpiresAt,
+	)
+	return tok, canonical, sig, nil
+}
+
+// VerifyRequest is the input to Service.Verify.
+type VerifyRequest struct {
+	ClaimsJSON []byte
+	Signature  []byte
+	AgentID    string
+	ActionType string
+	Target     string
+}
+
+// Verify returns the parsed token on success, or one of the
+// capability.Err* sentinels.
+func (s *Service) Verify(_ context.Context, req VerifyRequest) (*Token, error) {
+	var tok Token
+	if err := json.Unmarshal(req.ClaimsJSON, &tok); err != nil {
+		return nil, ErrMalformedToken
+	}
+	canonical, err := tok.Canonical()
+	if err != nil {
+		return nil, ErrMalformedToken
+	}
+	if !ed25519.Verify(s.signPub, canonical, req.Signature) {
+		return nil, ErrInvalidSignature
+	}
+	if s.clock().Unix() >= tok.ExpiresAt {
+		return nil, ErrExpired
+	}
+	if s.revocation.IsRevoked(tok.TokenID) {
+		return nil, ErrRevoked
+	}
+	if tok.AgentID != req.AgentID {
+		return nil, ErrAgentMismatch
+	}
+	actionOK, targetOK := tok.Allows(req.ActionType, req.Target)
+	if !actionOK {
+		return nil, ErrActionTypeNotAllowed
+	}
+	if !targetOK {
+		return nil, ErrTargetNotAllowed
+	}
+	return &tok, nil
+}
+
+// Revoke records tokenID in the revocation set. Idempotent.
+func (s *Service) Revoke(_ context.Context, tokenID string) {
+	s.revocation.Revoke(tokenID)
+	s.logger.Info("token revoked", "token_id", tokenID)
+}
+
+// SigningPublicKey returns the service's Ed25519 public key for
+// out-of-band signature inspection.
+func (s *Service) SigningPublicKey() ed25519.PublicKey {
+	return append(ed25519.PublicKey(nil), s.signPub...)
+}

--- a/go-key-service/internal/capability/service_test.go
+++ b/go-key-service/internal/capability/service_test.go
@@ -1,0 +1,267 @@
+package capability
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+)
+
+func newTestService(t *testing.T, now time.Time) (*Service, keystore.KeyStore) {
+	t.Helper()
+	store := keystore.NewMemory()
+	if _, err := store.Create(context.Background(), "agent-1"); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	clock := func() time.Time { return now }
+	svc, err := NewService(store, Options{
+		Clock:  clock,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, store
+}
+
+func issueTestToken(t *testing.T, svc *Service, agent string, types, targets []string, ttl int64) (*Token, []byte, []byte) {
+	t.Helper()
+	tok, claims, sig, err := svc.Issue(context.Background(), IssueRequest{
+		AgentID:     agent,
+		ActionTypes: types,
+		Targets:     targets,
+		TTLSeconds:  ttl,
+	})
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	return tok, claims, sig
+}
+
+func TestIssueHappyPath(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	svc, _ := newTestService(t, now)
+	tok, claims, sig := issueTestToken(t, svc, "agent-1", []string{"transfer"}, []string{"acct:1"}, 3600)
+
+	if tok.TokenID == "" {
+		t.Fatalf("token_id is empty")
+	}
+	if tok.IssuedAt != now.Unix() {
+		t.Fatalf("issued_at: got %d want %d", tok.IssuedAt, now.Unix())
+	}
+	if tok.ExpiresAt != now.Unix()+3600 {
+		t.Fatalf("expires_at: got %d want %d", tok.ExpiresAt, now.Unix()+3600)
+	}
+	if !ed25519.Verify(svc.SigningPublicKey(), claims, sig) {
+		t.Fatalf("signature does not verify")
+	}
+}
+
+func TestIssueRejectsUnknownAgent(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	_, _, _, err := svc.Issue(context.Background(), IssueRequest{
+		AgentID:     "ghost",
+		ActionTypes: []string{"x"},
+		Targets:     []string{"y"},
+		TTLSeconds:  60,
+	})
+	if !errors.Is(err, ErrUnknownAgent) {
+		t.Fatalf("got %v want ErrUnknownAgent", err)
+	}
+}
+
+func TestIssueRejectsInvalidTTL(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	for _, ttl := range []int64{0, -1} {
+		_, _, _, err := svc.Issue(context.Background(), IssueRequest{
+			AgentID:     "agent-1",
+			ActionTypes: []string{"x"},
+			Targets:     []string{"y"},
+			TTLSeconds:  ttl,
+		})
+		if !errors.Is(err, ErrInvalidTTL) {
+			t.Fatalf("ttl=%d: got %v want ErrInvalidTTL", ttl, err)
+		}
+	}
+}
+
+func TestIssueGeneratesUniqueTokenIDs(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	a, _, _ := issueTestToken(t, svc, "agent-1", []string{"x"}, []string{"y"}, 60)
+	b, _, _ := issueTestToken(t, svc, "agent-1", []string{"x"}, []string{"y"}, 60)
+	if a.TokenID == b.TokenID {
+		t.Fatalf("expected unique token_ids, both = %q", a.TokenID)
+	}
+}
+
+func TestCanonicalSortsListsAndKeys(t *testing.T) {
+	tok := &Token{
+		TokenID:     "id",
+		AgentID:     "a",
+		ActionTypes: []string{"z", "a", "m"},
+		Targets:     []string{"t2", "t1"},
+		IssuedAt:    1,
+		ExpiresAt:   2,
+	}
+	got, err := tok.Canonical()
+	if err != nil {
+		t.Fatalf("Canonical: %v", err)
+	}
+	want := `{"action_types":["a","m","z"],"agent_id":"a","expires_at":2,"issued_at":1,"targets":["t1","t2"],"token_id":"id"}`
+	if string(got) != want {
+		t.Fatalf("canonical mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestVerifyHappyPath(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	svc, _ := newTestService(t, now)
+	_, claims, sig := issueTestToken(t, svc, "agent-1", []string{"transfer"}, []string{"acct:1"}, 3600)
+
+	tok, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims,
+		Signature:  sig,
+		AgentID:    "agent-1",
+		ActionType: "transfer",
+		Target:     "acct:1",
+	})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if tok == nil || tok.AgentID != "agent-1" {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+}
+
+func TestVerifyExpiredAtBoundary(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	svc, _ := newTestService(t, now)
+	tok, claims, sig := issueTestToken(t, svc, "agent-1", []string{"x"}, []string{"y"}, 60)
+
+	// Tick clock forward to exactly expires_at — should be expired.
+	svc.clock = func() time.Time { return time.Unix(tok.ExpiresAt, 0) }
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims, Signature: sig,
+		AgentID: "agent-1", ActionType: "x", Target: "y",
+	})
+	if !errors.Is(err, ErrExpired) {
+		t.Fatalf("at boundary: got %v want ErrExpired", err)
+	}
+}
+
+func TestVerifyRevoked(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	tok, claims, sig := issueTestToken(t, svc, "agent-1", []string{"x"}, []string{"y"}, 600)
+	svc.Revoke(context.Background(), tok.TokenID)
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims, Signature: sig,
+		AgentID: "agent-1", ActionType: "x", Target: "y",
+	})
+	if !errors.Is(err, ErrRevoked) {
+		t.Fatalf("got %v want ErrRevoked", err)
+	}
+	// Re-revoke is idempotent.
+	svc.Revoke(context.Background(), tok.TokenID)
+}
+
+func TestVerifyAgentMismatch(t *testing.T) {
+	svc, store := newTestService(t, time.Unix(1_700_000_000, 0))
+	if _, err := store.Create(context.Background(), "agent-2"); err != nil {
+		t.Fatalf("seed agent-2: %v", err)
+	}
+	_, claims, sig := issueTestToken(t, svc, "agent-1", []string{"x"}, []string{"y"}, 600)
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims, Signature: sig,
+		AgentID: "agent-2", ActionType: "x", Target: "y",
+	})
+	if !errors.Is(err, ErrAgentMismatch) {
+		t.Fatalf("got %v want ErrAgentMismatch", err)
+	}
+}
+
+func TestVerifyActionTypeNotAllowed(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	_, claims, sig := issueTestToken(t, svc, "agent-1", []string{"transfer"}, []string{"y"}, 600)
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims, Signature: sig,
+		AgentID: "agent-1", ActionType: "withdraw", Target: "y",
+	})
+	if !errors.Is(err, ErrActionTypeNotAllowed) {
+		t.Fatalf("got %v want ErrActionTypeNotAllowed", err)
+	}
+}
+
+func TestVerifyTargetNotAllowed(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	_, claims, sig := issueTestToken(t, svc, "agent-1", []string{"transfer"}, []string{"acct:1"}, 600)
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims, Signature: sig,
+		AgentID: "agent-1", ActionType: "transfer", Target: "acct:2",
+	})
+	if !errors.Is(err, ErrTargetNotAllowed) {
+		t.Fatalf("got %v want ErrTargetNotAllowed", err)
+	}
+}
+
+func TestVerifyWildcards(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	_, claims, sig := issueTestToken(t, svc, "agent-1", []string{"*"}, []string{"*"}, 600)
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims, Signature: sig,
+		AgentID: "agent-1", ActionType: "anything", Target: "whatever",
+	})
+	if err != nil {
+		t.Fatalf("wildcards should match: %v", err)
+	}
+}
+
+func TestVerifyTamperedSignature(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	_, claims, sig := issueTestToken(t, svc, "agent-1", []string{"x"}, []string{"y"}, 600)
+	tampered := append([]byte(nil), sig...)
+	tampered[0] ^= 0x01
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: claims, Signature: tampered,
+		AgentID: "agent-1", ActionType: "x", Target: "y",
+	})
+	if !errors.Is(err, ErrInvalidSignature) {
+		t.Fatalf("got %v want ErrInvalidSignature", err)
+	}
+}
+
+func TestVerifyTamperedClaims(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	_, claims, sig := issueTestToken(t, svc, "agent-1", []string{"x"}, []string{"y"}, 600)
+	// Modify a field after signing — signature must no longer verify.
+	var m map[string]any
+	if err := json.Unmarshal(claims, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	m["agent_id"] = "agent-evil"
+	tampered, _ := json.Marshal(m)
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: tampered, Signature: sig,
+		AgentID: "agent-evil", ActionType: "x", Target: "y",
+	})
+	if !errors.Is(err, ErrInvalidSignature) {
+		t.Fatalf("got %v want ErrInvalidSignature", err)
+	}
+}
+
+func TestVerifyMalformedClaims(t *testing.T) {
+	svc, _ := newTestService(t, time.Unix(1_700_000_000, 0))
+	_, err := svc.Verify(context.Background(), VerifyRequest{
+		ClaimsJSON: []byte("not-json"),
+		Signature:  make([]byte, ed25519.SignatureSize),
+		AgentID:    "agent-1", ActionType: "x", Target: "y",
+	})
+	if !errors.Is(err, ErrMalformedToken) {
+		t.Fatalf("got %v want ErrMalformedToken", err)
+	}
+}

--- a/go-key-service/internal/capability/token.go
+++ b/go-key-service/internal/capability/token.go
@@ -1,0 +1,83 @@
+// Package capability issues, verifies, and revokes scoped capability
+// tokens. A token authorizes a specific agent to perform a bounded set
+// of (action_type, target) pairs until expiry.
+package capability
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+)
+
+// Wildcard matches any value when present in Token.ActionTypes or
+// Token.Targets. The literal "*" string is the only special case; no
+// glob expansion is performed.
+const Wildcard = "*"
+
+// Token is the claim set the service signs. The detached Ed25519
+// signature lives separately on the wire.
+type Token struct {
+	TokenID     string   `json:"token_id"`
+	AgentID     string   `json:"agent_id"`
+	ActionTypes []string `json:"action_types"`
+	Targets     []string `json:"targets"`
+	IssuedAt    int64    `json:"issued_at"`
+	ExpiresAt   int64    `json:"expires_at"`
+}
+
+// Canonical returns the deterministic JSON bytes used for signing.
+// Keys are sorted (encoding/json sorts map keys); list entries are
+// sorted; no insignificant whitespace.
+func (t *Token) Canonical() ([]byte, error) {
+	actionTypes := append([]string(nil), t.ActionTypes...)
+	sort.Strings(actionTypes)
+	targets := append([]string(nil), t.Targets...)
+	sort.Strings(targets)
+	m := map[string]any{
+		"token_id":     t.TokenID,
+		"agent_id":     t.AgentID,
+		"action_types": actionTypes,
+		"targets":      targets,
+		"issued_at":    t.IssuedAt,
+		"expires_at":   t.ExpiresAt,
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(m); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// Allows reports whether actionType and target both satisfy the token's
+// scope (exact match or Wildcard).
+func (t *Token) Allows(actionType, target string) (actionOK, targetOK bool) {
+	return contains(t.ActionTypes, actionType), contains(t.Targets, target)
+}
+
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == Wildcard || v == want {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	ErrMalformedToken       = errors.New("capability: malformed token")
+	ErrInvalidSignature     = errors.New("capability: invalid signature")
+	ErrExpired              = errors.New("capability: token expired")
+	ErrRevoked              = errors.New("capability: token revoked")
+	ErrAgentMismatch        = errors.New("capability: agent_id does not match token")
+	ErrActionTypeNotAllowed = errors.New("capability: action_type not allowed by token")
+	ErrTargetNotAllowed     = errors.New("capability: target not allowed by token")
+	ErrUnknownAgent         = errors.New("capability: unknown agent")
+	ErrInvalidTTL           = errors.New("capability: ttl_seconds must be > 0")
+)

--- a/go-key-service/internal/httpapi/handlers.go
+++ b/go-key-service/internal/httpapi/handlers.go
@@ -13,13 +13,16 @@ import (
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
 	auditloghttp "github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog/http"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/capability"
+	capabilityhttp "github.com/knhn1004/CryptoAgent/go-key-service/internal/capability/http"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
 )
 
 type Server struct {
-	store    keystore.KeyStore
-	pipeline *auditlog.Pipeline
-	logger   *slog.Logger
+	store      keystore.KeyStore
+	pipeline   *auditlog.Pipeline
+	capability *capability.Service
+	logger     *slog.Logger
 }
 
 func NewServer(store keystore.KeyStore, logger *slog.Logger) *Server {
@@ -37,6 +40,13 @@ func (s *Server) WithAuditPipeline(p *auditlog.Pipeline) *Server {
 	return s
 }
 
+// WithCapability mounts the capability (token) endpoints on the same
+// router. Optional; tests that don't need tokens can omit this.
+func (s *Server) WithCapability(c *capability.Service) *Server {
+	s.capability = c
+	return s
+}
+
 func (s *Server) Router() http.Handler {
 	r := chi.NewRouter()
 	r.Use(s.logRequests)
@@ -51,6 +61,9 @@ func (s *Server) Router() http.Handler {
 	})
 	if s.pipeline != nil {
 		auditloghttp.Mount(r, s.pipeline, s.logger)
+	}
+	if s.capability != nil {
+		capabilityhttp.Mount(r, s.capability, s.logger)
 	}
 	return r
 }

--- a/sdk-python/cryptoagent/__init__.py
+++ b/sdk-python/cryptoagent/__init__.py
@@ -15,6 +15,7 @@ from .decorators import (
     current_signed_action,
     multi_sig,
     requires_capability,
+    requires_token,
     signed_action,
 )
 from .multisig import (
@@ -41,6 +42,16 @@ from .signing import (
     sign,
     verify,
 )
+from .tokens import (
+    Token,
+    TokenClient,
+    TokenError,
+    TokenServiceUnavailableError,
+    clear_token,
+    current_token,
+    set_token,
+    token_context,
+)
 
 __all__ = [
     "ACL",
@@ -65,12 +76,21 @@ __all__ = [
     "SignatureError",
     "ThresholdNotMetError",
     "ThresholdNotReached",
+    "Token",
+    "TokenClient",
+    "TokenError",
+    "TokenServiceUnavailableError",
+    "clear_token",
     "current_signed_action",
+    "current_token",
     "gated",
     "generate_keypair",
     "multi_sig",
     "requires_capability",
+    "requires_token",
+    "set_token",
     "sign",
     "signed_action",
+    "token_context",
     "verify",
 ]

--- a/sdk-python/cryptoagent/decorators.py
+++ b/sdk-python/cryptoagent/decorators.py
@@ -3,7 +3,9 @@
 * :func:`signed_action` — sign every invocation and attach the signed
   action + signature to a thread-local context downstream consumers can
   read via :func:`current_signed_action`.
-* :func:`requires_capability` — gate a call on an ACL membership check.
+* :func:`requires_capability` — gate a call on an in-memory ACL check.
+* :func:`requires_token` — gate a call on a service-issued scoped token,
+  verified by the Go service. Fail-closed.
 * :func:`multi_sig` — route a call through a :class:`Gate` so it is only
   executed when ``threshold`` distinct valid signers approved it.
 """
@@ -20,6 +22,7 @@ from .acl import ACL
 from .action import Action
 from .multisig import Gate
 from .signing import sign
+from .tokens import TokenClient, TokenError, current_token
 
 _context = threading.local()
 
@@ -104,6 +107,48 @@ def requires_capability(
             if agent_id_arg not in kwargs:
                 raise TypeError(f"@requires_capability needs kwarg {agent_id_arg!r}")
             acl.require(kwargs[agent_id_arg], capability)
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return deco
+
+
+def requires_token(
+    client: TokenClient,
+    *,
+    action_type: str,
+    target: str,
+) -> Callable:
+    """Reject the call unless the active token authorizes
+    ``(action_type, target)`` for the calling agent.
+
+    Reads the active :class:`~cryptoagent.tokens.Token` from the
+    :func:`~cryptoagent.tokens.token_context` and the calling agent_id
+    from the surrounding ``@signed_action`` context, then asks the
+    service to verify. Any non-200 response (including network errors)
+    aborts the call — this is the security gate, fail-closed.
+
+    Must be applied *inside* ``@signed_action`` so the agent_id is
+    available.
+    """
+
+    def deco(fn: Callable) -> Callable:
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            ctx = current_signed_action()
+            if ctx is None:
+                raise TokenError("@requires_token must be inside @signed_action")
+            action, _ = ctx
+            token = current_token()
+            if token is None:
+                raise TokenError("no active token in context")
+            client.verify(
+                token,
+                action_type=action_type,
+                target=target,
+                agent_id=action.agent_id,
+            )
             return fn(*args, **kwargs)
 
         return wrapper

--- a/sdk-python/cryptoagent/tokens.py
+++ b/sdk-python/cryptoagent/tokens.py
@@ -1,0 +1,225 @@
+"""Scoped capability tokens issued by the Go key-service.
+
+A :class:`Token` is opaque-ish JSON returned by the service plus a
+detached Ed25519 signature. The SDK never verifies the signature itself;
+verification is server-authoritative via :meth:`TokenClient.verify`. The
+SDK keeps the original ``claims_json`` bytes so every verify call sends
+back exactly what the service signed (avoids canonicalization drift).
+
+Decorators that gate an action on a token live in :mod:`.decorators`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+
+class TokenError(PermissionError):
+    """Service refused a token operation, or the SDK could not produce
+    one. Subclasses :class:`PermissionError` so the existing decorator
+    stack handles it like :class:`~cryptoagent.acl.CapabilityError`.
+
+    ``error_code`` is the service's machine code (e.g. ``"expired"``,
+    ``"revoked"``) for server-originated errors, or ``None`` for
+    client-side errors (missing context, etc.).
+    """
+
+    def __init__(self, message: str, *, error_code: str | None = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class TokenServiceUnavailableError(TokenError):
+    """Service unreachable, timed out, or returned 5xx. Fail-closed: the
+    decorator denies the action."""
+
+
+@dataclass(frozen=True)
+class Token:
+    """A capability token returned by the service.
+
+    ``claims_json`` is the exact byte string the service signed; never
+    re-marshal it. The remaining fields are convenience accessors parsed
+    from ``claims_json`` for filtering/logging — they are *not*
+    authoritative.
+    """
+
+    claims_json: str
+    signature_hex: str
+    token_id: str
+    agent_id: str
+    expires_at: int
+
+    @classmethod
+    def from_response(cls, body: dict[str, Any]) -> Token:
+        claims_json = body["claims_json"]
+        sig_hex = body["signature_hex"]
+        claims = json.loads(claims_json)
+        return cls(
+            claims_json=claims_json,
+            signature_hex=sig_hex,
+            token_id=body.get("token_id") or claims["token_id"],
+            agent_id=claims["agent_id"],
+            expires_at=int(claims["expires_at"]),
+        )
+
+
+_context = threading.local()
+
+
+def current_token() -> Token | None:
+    """Return the active token in this thread, or ``None``."""
+    stack = getattr(_context, "stack", None)
+    if not stack:
+        return None
+    return stack[-1]
+
+
+def set_token(token: Token) -> None:
+    """Push ``token`` onto the active stack. Call :func:`clear_token`
+    when done."""
+    stack = getattr(_context, "stack", None)
+    if stack is None:
+        stack = []
+        _context.stack = stack
+    stack.append(token)
+
+
+def clear_token() -> None:
+    """Pop the most recent token. No-op if the stack is empty."""
+    stack = getattr(_context, "stack", None)
+    if stack:
+        stack.pop()
+
+
+@contextlib.contextmanager
+def token_context(token: Token) -> Iterator[Token]:
+    """Bind ``token`` as the active token for the duration of the
+    ``with`` block."""
+    set_token(token)
+    try:
+        yield token
+    finally:
+        clear_token()
+
+
+class _UrllibClient:
+    """Default HTTP client. Stdlib only — same approach as
+    :class:`~cryptoagent.proposal._UrllibPoster`."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        body: dict[str, Any] | None,
+        timeout: float,
+    ) -> tuple[int, bytes]:
+        data = None
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — caller-owned URL
+                return int(resp.status), resp.read()
+        except urllib.error.HTTPError as e:
+            return int(e.code), e.read() or b""
+
+
+class TokenClient:
+    """Client for the Go service's ``/v1/tokens`` endpoints.
+
+    All methods raise :class:`TokenError` (or
+    :class:`TokenServiceUnavailableError`) on failure. The client is
+    thread-safe to share if the underlying ``http`` client is.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 5.0,
+        http: Any = None,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._timeout = timeout
+        self._http = http or _UrllibClient()
+
+    def issue(
+        self,
+        agent_id: str,
+        action_types: Iterable[str],
+        targets: Iterable[str],
+        ttl_seconds: int,
+    ) -> Token:
+        body = {
+            "agent_id": agent_id,
+            "action_types": list(action_types),
+            "targets": list(targets),
+            "ttl_seconds": int(ttl_seconds),
+        }
+        status, payload = self._do("POST", "/v1/tokens", body)
+        if status != 201:
+            raise self._error_from(status, payload)
+        return Token.from_response(json.loads(payload))
+
+    def verify(
+        self,
+        token: Token,
+        *,
+        action_type: str,
+        target: str,
+        agent_id: str,
+    ) -> None:
+        body = {
+            "claims_json": token.claims_json,
+            "signature_hex": token.signature_hex,
+            "agent_id": agent_id,
+            "action_type": action_type,
+            "target": target,
+        }
+        status, payload = self._do("POST", "/v1/tokens/verify", body)
+        if status != 200:
+            raise self._error_from(status, payload)
+
+    def revoke(self, token_id: str) -> None:
+        status, payload = self._do("POST", f"/v1/tokens/{token_id}/revoke", None)
+        if status != 204:
+            raise self._error_from(status, payload)
+
+    def _do(
+        self, method: str, path: str, body: dict[str, Any] | None
+    ) -> tuple[int, bytes]:
+        try:
+            return self._http.request(
+                method, self._base + path, body=body, timeout=self._timeout
+            )
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            raise TokenServiceUnavailableError(
+                f"token service unreachable: {e}"
+            ) from e
+
+    @staticmethod
+    def _error_from(status: int, payload: bytes) -> TokenError:
+        code: str | None = None
+        message = f"HTTP {status}"
+        try:
+            envelope = json.loads(payload) if payload else {}
+        except json.JSONDecodeError:
+            envelope = {}
+        if isinstance(envelope, dict):
+            code = envelope.get("error") or None
+            if envelope.get("message"):
+                message = envelope["message"]
+        if status >= 500:
+            return TokenServiceUnavailableError(message, error_code=code)
+        return TokenError(message, error_code=code)

--- a/sdk-python/cryptoagent/tokens.py
+++ b/sdk-python/cryptoagent/tokens.py
@@ -196,17 +196,11 @@ class TokenClient:
         if status != 204:
             raise self._error_from(status, payload)
 
-    def _do(
-        self, method: str, path: str, body: dict[str, Any] | None
-    ) -> tuple[int, bytes]:
+    def _do(self, method: str, path: str, body: dict[str, Any] | None) -> tuple[int, bytes]:
         try:
-            return self._http.request(
-                method, self._base + path, body=body, timeout=self._timeout
-            )
+            return self._http.request(method, self._base + path, body=body, timeout=self._timeout)
         except (urllib.error.URLError, TimeoutError, OSError) as e:
-            raise TokenServiceUnavailableError(
-                f"token service unreachable: {e}"
-            ) from e
+            raise TokenServiceUnavailableError(f"token service unreachable: {e}") from e
 
     @staticmethod
     def _error_from(status: int, payload: bytes) -> TokenError:

--- a/sdk-python/tests/test_tokens.py
+++ b/sdk-python/tests/test_tokens.py
@@ -65,9 +65,7 @@ class _Handler(BaseHTTPRequestHandler):
 
     def _serve(self, method: str) -> None:
         body = self._read()
-        self.service.calls.append(
-            {"method": method, "path": self.path, "body": body}
-        )
+        self.service.calls.append({"method": method, "path": self.path, "body": body})
         status, payload = self.service.pop()
         self.send_response(status)
         if payload is None:
@@ -324,9 +322,7 @@ def test_requires_token_service_denies(fake_service):
     svc.queue(403, {"error": "expired", "message": "expired"})
 
     client = TokenClient(base)
-    fn = _make_action_decorated(
-        client, fn=lambda: pytest.fail("wrapped fn should not run")
-    )
+    fn = _make_action_decorated(client, fn=lambda: pytest.fail("wrapped fn should not run"))
     with token_context(Token.from_response(_issue_response())):
         with pytest.raises(TokenError) as info:
             fn()
@@ -338,9 +334,7 @@ def test_requires_token_fails_closed_on_5xx(fake_service):
     svc.queue(503, {"error": "internal", "message": "down"})
 
     client = TokenClient(base)
-    fn = _make_action_decorated(
-        client, fn=lambda: pytest.fail("wrapped fn should not run on 5xx")
-    )
+    fn = _make_action_decorated(client, fn=lambda: pytest.fail("wrapped fn should not run on 5xx"))
     with token_context(Token.from_response(_issue_response())):
         with pytest.raises(TokenServiceUnavailableError):
             fn()

--- a/sdk-python/tests/test_tokens.py
+++ b/sdk-python/tests/test_tokens.py
@@ -1,0 +1,351 @@
+"""Tests for the scoped capability token client and decorator.
+
+The TokenClient is exercised against a stdlib http.server fake — no
+network, no extra deps. The fake records every call so tests can assert
+the wire shape too.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+from cryptoagent.action import Action
+from cryptoagent.decorators import requires_token, signed_action
+from cryptoagent.signing import generate_keypair
+from cryptoagent.tokens import (
+    Token,
+    TokenClient,
+    TokenError,
+    TokenServiceUnavailableError,
+    clear_token,
+    current_token,
+    set_token,
+    token_context,
+)
+
+# ---------- fixtures: in-process fake service ---------------------------
+
+
+class _FakeService:
+    """Drives a per-test HTTP server that replays canned responses."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses: list[tuple[int, dict[str, Any] | None]] = []
+
+    def queue(self, status: int, body: dict[str, Any] | None) -> None:
+        self.responses.append((status, body))
+
+    def pop(self) -> tuple[int, dict[str, Any] | None]:
+        if not self.responses:
+            return 200, {"ok": True}
+        return self.responses.pop(0)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    service: _FakeService  # set by factory
+
+    def log_message(self, *args, **kwargs) -> None:  # silence test noise
+        pass
+
+    def _read(self) -> dict[str, Any] | None:
+        length = int(self.headers.get("Content-Length") or "0")
+        if length == 0:
+            return None
+        raw = self.rfile.read(length)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+
+    def _serve(self, method: str) -> None:
+        body = self._read()
+        self.service.calls.append(
+            {"method": method, "path": self.path, "body": body}
+        )
+        status, payload = self.service.pop()
+        self.send_response(status)
+        if payload is None:
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        else:
+            data = json.dumps(payload).encode("utf-8")
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+    def do_POST(self) -> None:  # noqa: N802 — http.server contract
+        self._serve("POST")
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._serve("GET")
+
+
+@pytest.fixture
+def fake_service():
+    svc = _FakeService()
+
+    handler_cls = type("H", (_Handler,), {"service": svc})
+    httpd = HTTPServer(("127.0.0.1", 0), handler_cls)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield svc, f"http://127.0.0.1:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def _claims_payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "token_id": "tok-1",
+        "agent_id": "agent-a",
+        "action_types": ["transfer"],
+        "targets": ["acct:1"],
+        "issued_at": 1_700_000_000,
+        "expires_at": 1_700_003_600,
+    }
+    base.update(overrides)
+    return base
+
+
+def _issue_response(claims: dict[str, Any] | None = None) -> dict[str, Any]:
+    claims = claims or _claims_payload()
+    return {
+        "token_id": claims["token_id"],
+        "claims_json": json.dumps(claims),
+        "signature_hex": "ab" * 64,
+    }
+
+
+# ---------- Token dataclass ---------------------------------------------
+
+
+def test_token_from_response_parses_convenience_fields():
+    body = _issue_response()
+    tok = Token.from_response(body)
+    assert tok.token_id == "tok-1"
+    assert tok.agent_id == "agent-a"
+    assert tok.expires_at == 1_700_003_600
+    # claims_json is preserved verbatim, never re-marshaled.
+    assert tok.claims_json == body["claims_json"]
+
+
+# ---------- token_context / current_token -------------------------------
+
+
+def test_token_context_sets_and_clears():
+    tok = Token.from_response(_issue_response())
+    assert current_token() is None
+    with token_context(tok):
+        assert current_token() is tok
+    assert current_token() is None
+
+
+def test_set_and_clear_token():
+    a = Token.from_response(_issue_response())
+    b = Token.from_response(_issue_response(_claims_payload(token_id="tok-2")))
+    set_token(a)
+    set_token(b)
+    assert current_token() is b
+    clear_token()
+    assert current_token() is a
+    clear_token()
+    assert current_token() is None
+    # extra clear is a no-op
+    clear_token()
+
+
+# ---------- TokenClient happy paths -------------------------------------
+
+
+def test_client_issue_happy(fake_service):
+    svc, base = fake_service
+    svc.queue(201, _issue_response())
+
+    client = TokenClient(base)
+    tok = client.issue("agent-a", ["transfer"], ["acct:1"], 3600)
+
+    assert tok.agent_id == "agent-a"
+    call = svc.calls[0]
+    assert call["method"] == "POST"
+    assert call["path"] == "/v1/tokens"
+    assert call["body"] == {
+        "agent_id": "agent-a",
+        "action_types": ["transfer"],
+        "targets": ["acct:1"],
+        "ttl_seconds": 3600,
+    }
+
+
+def test_client_verify_happy(fake_service):
+    svc, base = fake_service
+    svc.queue(200, {"ok": True, "token_id": "tok-1"})
+
+    client = TokenClient(base)
+    tok = Token.from_response(_issue_response())
+    client.verify(tok, action_type="transfer", target="acct:1", agent_id="agent-a")
+
+    call = svc.calls[0]
+    assert call["path"] == "/v1/tokens/verify"
+    body = call["body"]
+    # claims_json round-tripped exactly so the server can re-verify the
+    # signature against bytes it produced.
+    assert body["claims_json"] == tok.claims_json
+    assert body["signature_hex"] == tok.signature_hex
+    assert body["action_type"] == "transfer"
+    assert body["target"] == "acct:1"
+    assert body["agent_id"] == "agent-a"
+
+
+def test_client_revoke_happy(fake_service):
+    svc, base = fake_service
+    svc.queue(204, None)
+
+    TokenClient(base).revoke("tok-1")
+    assert svc.calls[0]["path"] == "/v1/tokens/tok-1/revoke"
+
+
+# ---------- TokenClient error mapping -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "status,error_code,exc",
+    [
+        (400, "invalid_json", TokenError),
+        (400, "malformed_token", TokenError),
+        (401, "invalid_signature", TokenError),
+        (403, "expired", TokenError),
+        (403, "revoked", TokenError),
+        (403, "agent_mismatch", TokenError),
+        (403, "action_type_not_allowed", TokenError),
+        (403, "target_not_allowed", TokenError),
+        (404, "unknown_agent", TokenError),
+        (500, "internal", TokenServiceUnavailableError),
+        (502, "internal", TokenServiceUnavailableError),
+    ],
+)
+def test_verify_error_mapping(fake_service, status, error_code, exc):
+    svc, base = fake_service
+    svc.queue(status, {"error": error_code, "message": "no"})
+
+    client = TokenClient(base)
+    tok = Token.from_response(_issue_response())
+    with pytest.raises(exc) as info:
+        client.verify(tok, action_type="x", target="y", agent_id="agent-a")
+    assert info.value.error_code == error_code
+
+
+def test_client_unreachable_raises_unavailable():
+    # Open then immediately close a server so we know the port is free
+    # and nothing will answer on it.
+    s = HTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    port = s.server_address[1]
+    s.server_close()
+
+    client = TokenClient(f"http://127.0.0.1:{port}", timeout=0.5)
+    tok = Token.from_response(_issue_response())
+    with pytest.raises(TokenServiceUnavailableError):
+        client.verify(tok, action_type="x", target="y", agent_id="agent-a")
+
+
+# ---------- @requires_token decorator -----------------------------------
+
+
+def _make_action_decorated(client: TokenClient, fn=None):
+    _, priv = generate_keypair()
+
+    def real(*args, **kwargs):
+        return "ok"
+
+    fn = fn or real
+
+    @signed_action(
+        agent_id="agent-a",
+        action_type="transfer",
+        target="acct:1",
+        private_key=priv,
+    )
+    @requires_token(client, action_type="transfer", target="acct:1")
+    def wrapped() -> str:
+        return fn()
+
+    return wrapped
+
+
+def test_requires_token_happy(fake_service):
+    svc, base = fake_service
+    svc.queue(200, {"ok": True, "token_id": "tok-1"})
+
+    client = TokenClient(base)
+    fn = _make_action_decorated(client)
+
+    with token_context(Token.from_response(_issue_response())):
+        assert fn() == "ok"
+
+    # The verify call carried the agent_id from the surrounding
+    # @signed_action context, not a hard-coded value.
+    body = svc.calls[0]["body"]
+    assert body["agent_id"] == "agent-a"
+
+
+def test_requires_token_no_signed_action_context(fake_service):
+    _, base = fake_service
+    client = TokenClient(base)
+
+    @requires_token(client, action_type="transfer", target="acct:1")
+    def naked() -> None:
+        pass
+
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError):
+            naked()
+
+
+def test_requires_token_no_token_in_context(fake_service):
+    _, base = fake_service
+    client = TokenClient(base)
+
+    fn = _make_action_decorated(client)
+    with pytest.raises(TokenError):
+        fn()  # token_context not entered
+
+
+def test_requires_token_service_denies(fake_service):
+    svc, base = fake_service
+    svc.queue(403, {"error": "expired", "message": "expired"})
+
+    client = TokenClient(base)
+    fn = _make_action_decorated(
+        client, fn=lambda: pytest.fail("wrapped fn should not run")
+    )
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError) as info:
+            fn()
+    assert info.value.error_code == "expired"
+
+
+def test_requires_token_fails_closed_on_5xx(fake_service):
+    svc, base = fake_service
+    svc.queue(503, {"error": "internal", "message": "down"})
+
+    client = TokenClient(base)
+    fn = _make_action_decorated(
+        client, fn=lambda: pytest.fail("wrapped fn should not run on 5xx")
+    )
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenServiceUnavailableError):
+            fn()
+
+
+# ---------- Action import is just to keep the namespace honest ----------
+
+_ = Action  # silence "unused import" if action ever stops being touched


### PR DESCRIPTION
## Summary

- Go: new internal/capability package (Token + canonical JSON, in-memory revocation store, Service with injected ed25519 signing key + clock) and HTTP handlers under `/v1/tokens` for issue/verify/revoke/signing-pubkey, wired into `cmd/keyserver`. 
- Python SDK: new `cryptoagent/tokens.py` (`Token`, `TokenClient`, `token_context/current_token`, `TokenError/TokenServiceUnavailableError`) plus a `@requires_token` decorator that fetches `agent_id` from `@signed_action`'s context and fails closed on 5xx / network errors.
- Tests: full unit + HTTP coverage for the Go capability layer (every error code, expiry boundary, wildcards, signature/claims tamper, revocation idempotency) and a Python suite that drives `TokenClient` against a `stdlib http.server` fake — no new runtime deps in either language (just `github.com/google/uuid`).

Closes #16 

## Acceptance checklist

- [x] Token format: agent_id, allowed action_types, allowed targets, expiry, signature by Go service
- [x] Token verification helper used by orchestrator
- [x] Revocation list / expiry honored

## Test plan

- [ ] `go test ./...` (in `go-key-service/`)
- [ ] `pytest -q` (in `sdk-python/`)
