### PR TITLE
feat(anchor): AuditAnchor contract + Go committer + indexer (#13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,4 @@ dashboard/.vite/
 # Foundry / contracts
 contracts/cache/
 contracts/out/
-contracts/lib/
 contracts/broadcast/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts/lib/forge-std"]
+	path = contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std.git

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,21 +1,104 @@
 # contracts
 
-Solidity anchoring contract that periodically commits Merkle roots from the
-audit log to an Ethereum testnet. Tooling: Foundry.
+`AuditAnchor` is the on-chain witness for the off-chain RFC 6962 Merkle audit log. A trusted committer (the Go key-service) periodically posts `(treeSize, root, timestamp)` so any auditor can re-run consistency proofs against the live tree and detect rewrites the log operator can no longer hide.
+
+Tooling: Foundry.
+
+## Layout
+
+```
+contracts/
+├── foundry.toml
+├── src/AuditAnchor.sol            # the contract
+├── test/AuditAnchor.t.sol         # forge tests (14 cases)
+├── script/DeployAuditAnchor.s.sol # deploy script
+└── lib/forge-std                  # submodule
+```
 
 ## Setup
 
 ```sh
 curl -L https://foundry.paradigm.xyz | bash
 foundryup
-forge init --no-git --no-commit .
+git submodule update --init --recursive
 ```
-
-(Re-runs of `forge init` in this directory are no-ops once `foundry.toml` exists.)
 
 ## Build / test
 
 ```sh
+cd contracts
 forge build
-forge test
+forge test -vv
 ```
+
+## Deploy (Sepolia)
+
+```sh
+export SEPOLIA_RPC_URL="https://..."
+export DEPLOYER_PRIVATE_KEY="0x..."
+export COMMITTER_ADDRESS="0x..."          # the address the Go service signs from
+export ETHERSCAN_API_KEY="..."
+
+forge script script/DeployAuditAnchor.s.sol \
+  --rpc-url $SEPOLIA_RPC_URL \
+  --private-key $DEPLOYER_PRIVATE_KEY \
+  --broadcast --verify
+```
+
+After deployment, record the address in `docs/deployments.md` and pass it to the Go service via `ANCHOR_CONTRACT_ADDRESS`.
+
+## Wiring the committer
+
+The Go side talks to the contract through the foundry `cast` binary so we don't pull go-ethereum into `go.mod`. Required env vars on the keyserver:
+
+| Variable                    | Required for `ANCHOR_MODE=cast` | Notes |
+|-----------------------------|---------------------------------|-------|
+| `ANCHOR_MODE`               | yes (`cast`, `dry-run`, or `off`) | `off` is the default |
+| `ANCHOR_INTERVAL`           | optional                        | default `15m`, any Go duration |
+| `ANCHOR_CONTRACT_ADDRESS`   | yes for `cast`                  | deployed `AuditAnchor` address |
+| `ANCHOR_RPC_URL`            | yes for `cast`                  | Sepolia or any EVM JSON-RPC |
+| `ANCHOR_PRIVATE_KEY`        | yes for `cast`                  | committer key (hex, 0x-prefixed) |
+| `ANCHOR_CAST_BINARY`        | optional                        | path override; defaults to `cast` |
+
+Indexer endpoint:
+
+```
+GET /v1/anchor/latest
+{
+  "id": 7,
+  "tree_size": 42,
+  "root_hex": "0xab…",
+  "timestamp_ms": 1700000000500,
+  "block_number": 12345,
+  "tx_hash": "0xdeadbeef"
+}
+```
+
+## Contract surface
+
+```solidity
+event AuditAnchored(
+    uint256 indexed id,
+    uint64  treeSize,
+    bytes32 indexed root,
+    uint64  blockNumber,
+    uint64  timestamp
+);
+
+function commit(uint64 treeSize, bytes32 root, uint64 timestamp) external returns (uint256 id);
+function latest() external view returns (Anchor memory);
+function anchorAt(uint256 id) external view returns (Anchor memory);
+function count() external view returns (uint256);
+
+function setCommitter(address next) external;        // owner only
+function transferOwnership(address next) external;   // two-step handover
+function acceptOwnership() external;
+```
+
+Reverts:
+
+- `EmptyTree` — `treeSize == 0`
+- `TreeShrank(last, next)` — `treeSize <= last anchor`
+- `NotCommitter` — only the configured committer may call `commit`
+- `NotOwner` / `NotPendingOwner` — admin guards
+- `ZeroAddress` — addresses passed to `constructor` / `setCommitter` / `transferOwnership` cannot be zero

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,0 +1,23 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.27"
+optimizer = true
+optimizer_runs = 200
+via_ir = false
+fs_permissions = [{ access = "read", path = "./" }]
+
+[fmt]
+line_length = 100
+tab_width = 4
+bracket_spacing = false
+int_types = "long"
+quote_style = "double"
+number_underscore = "thousands"
+
+[rpc_endpoints]
+sepolia = "${SEPOLIA_RPC_URL}"
+
+[etherscan]
+sepolia = { key = "${ETHERSCAN_API_KEY}" }

--- a/contracts/script/DeployAuditAnchor.s.sol
+++ b/contracts/script/DeployAuditAnchor.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Script, console} from "forge-std/Script.sol";
+import {AuditAnchor} from "../src/AuditAnchor.sol";
+
+/// @notice Deploys an AuditAnchor with the committer address read from
+///         env var COMMITTER_ADDRESS. Use:
+///
+///   forge script script/DeployAuditAnchor.s.sol \
+///     --rpc-url $SEPOLIA_RPC_URL \
+///     --private-key $DEPLOYER_PRIVATE_KEY \
+///     --broadcast --verify
+///
+/// The deployer becomes `owner`; `committer` is the address the
+/// Go service will sign anchor transactions from.
+contract DeployAuditAnchor is Script {
+    function run() external returns (AuditAnchor anchor) {
+        address committer = vm.envAddress("COMMITTER_ADDRESS");
+        vm.startBroadcast();
+        anchor = new AuditAnchor(committer);
+        vm.stopBroadcast();
+        console.log("AuditAnchor deployed at:", address(anchor));
+        console.log("Owner:", anchor.owner());
+        console.log("Committer:", anchor.committer());
+    }
+}

--- a/contracts/src/AuditAnchor.sol
+++ b/contracts/src/AuditAnchor.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+/// @title AuditAnchor
+/// @notice On-chain witness for the off-chain RFC 6962 Merkle audit log.
+///         A trusted committer periodically posts `(treeSize, root)` here
+///         so any auditor can re-run RFC 6962 consistency proofs against
+///         the live tree and detect rewrites the log operator can no
+///         longer hide.
+/// @dev    Designed to be deployed once per environment (Sepolia for the
+///         class demo). The `committer` is the single allowed signer for
+///         `commit`; ownership transfer is two-step to avoid bricking
+///         the contract on a typo.
+contract AuditAnchor {
+    /// @notice Anchor record stored at index `id`.
+    struct Anchor {
+        uint64 treeSize; // RFC 6962 leaf count at commit time
+        bytes32 root; // tree head hash (sha-256 in our impl)
+        uint64 timestamp; // committer's wall clock at submission (informational)
+        uint64 blockNumber; // chain block number — index key for off-chain readers
+    }
+
+    /// @notice Emitted once per successful commit. Indexers tail this.
+    event AuditAnchored(
+        uint256 indexed id, uint64 treeSize, bytes32 indexed root, uint64 blockNumber, uint64 timestamp
+    );
+
+    /// @notice Owner administers the committer set; cannot itself commit.
+    address public owner;
+    address public pendingOwner;
+
+    /// @notice Trusted committer. Only this address may call `commit`.
+    address public committer;
+
+    /// @notice Append-only ledger of anchors. `anchors.length` is the
+    ///         next id; older entries are never overwritten.
+    Anchor[] private anchors;
+
+    error NotOwner();
+    error NotPendingOwner();
+    error NotCommitter();
+    error EmptyTree();
+    error TreeShrank(uint64 last, uint64 next);
+    error ZeroAddress();
+
+    constructor(address initialCommitter) {
+        if (initialCommitter == address(0)) revert ZeroAddress();
+        owner = msg.sender;
+        committer = initialCommitter;
+    }
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    modifier onlyCommitter() {
+        if (msg.sender != committer) revert NotCommitter();
+        _;
+    }
+
+    /// @notice Commit a new anchor. Reverts if the tree size hasn't
+    ///         strictly grown — anchors must be monotonic so RFC 6962
+    ///         consistency proofs always have a smaller anchored size
+    ///         to extend from.
+    function commit(uint64 treeSize, bytes32 root, uint64 timestamp) external onlyCommitter returns (uint256 id) {
+        if (treeSize == 0) revert EmptyTree();
+        uint256 n = anchors.length;
+        if (n > 0) {
+            uint64 last = anchors[n - 1].treeSize;
+            if (treeSize <= last) revert TreeShrank(last, treeSize);
+        }
+        id = n;
+        anchors.push(
+            Anchor({treeSize: treeSize, root: root, timestamp: timestamp, blockNumber: uint64(block.number)})
+        );
+        emit AuditAnchored(id, treeSize, root, uint64(block.number), timestamp);
+    }
+
+    /// @notice Read an anchor by id. Reverts with the default solc
+    ///         out-of-bounds panic when id >= count.
+    function anchorAt(uint256 id) external view returns (Anchor memory) {
+        return anchors[id];
+    }
+
+    /// @notice Read the most-recent anchor. Reverts when no commits.
+    function latest() external view returns (Anchor memory) {
+        uint256 n = anchors.length;
+        if (n == 0) revert EmptyTree();
+        return anchors[n - 1];
+    }
+
+    /// @notice Total number of anchors ever committed.
+    function count() external view returns (uint256) {
+        return anchors.length;
+    }
+
+    /// @notice Rotate the committer. Owner-only; effective immediately.
+    function setCommitter(address next) external onlyOwner {
+        if (next == address(0)) revert ZeroAddress();
+        committer = next;
+    }
+
+    /// @notice Begin a two-step ownership handover.
+    function transferOwnership(address next) external onlyOwner {
+        if (next == address(0)) revert ZeroAddress();
+        pendingOwner = next;
+    }
+
+    /// @notice Pending owner accepts.
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert NotPendingOwner();
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+}

--- a/contracts/src/AuditAnchor.sol
+++ b/contracts/src/AuditAnchor.sol
@@ -25,6 +25,16 @@ contract AuditAnchor {
         uint256 indexed id, uint64 treeSize, bytes32 indexed root, uint64 blockNumber, uint64 timestamp
     );
 
+    /// @notice Emitted when the committer rotates. Both addresses indexed
+    ///         so observers can filter by either side of the swap.
+    event CommitterChanged(address indexed previous, address indexed next);
+
+    /// @notice Emitted when a two-step ownership handover begins.
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Emitted when the pending owner accepts ownership.
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
     /// @notice Owner administers the committer set; cannot itself commit.
     address public owner;
     address public pendingOwner;
@@ -98,19 +108,23 @@ contract AuditAnchor {
     /// @notice Rotate the committer. Owner-only; effective immediately.
     function setCommitter(address next) external onlyOwner {
         if (next == address(0)) revert ZeroAddress();
+        emit CommitterChanged(committer, next);
         committer = next;
     }
 
     /// @notice Begin a two-step ownership handover.
     function transferOwnership(address next) external onlyOwner {
         if (next == address(0)) revert ZeroAddress();
+        emit OwnershipTransferStarted(owner, next);
         pendingOwner = next;
     }
 
     /// @notice Pending owner accepts.
     function acceptOwnership() external {
         if (msg.sender != pendingOwner) revert NotPendingOwner();
+        address previous = owner;
         owner = pendingOwner;
         pendingOwner = address(0);
+        emit OwnershipTransferred(previous, owner);
     }
 }

--- a/contracts/test/AuditAnchor.t.sol
+++ b/contracts/test/AuditAnchor.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+import {AuditAnchor} from "../src/AuditAnchor.sol";
+
+contract AuditAnchorTest is Test {
+    AuditAnchor anchor;
+
+    address owner = address(0xA11CE);
+    address committer = address(0xB0B);
+    address mallory = address(0xBADD);
+
+    bytes32 constant ROOT_1 = bytes32(uint256(0xa1));
+    bytes32 constant ROOT_2 = bytes32(uint256(0xa2));
+
+    event AuditAnchored(
+        uint256 indexed id, uint64 treeSize, bytes32 indexed root, uint64 blockNumber, uint64 timestamp
+    );
+
+    function setUp() public {
+        vm.prank(owner);
+        anchor = new AuditAnchor(committer);
+    }
+
+    function test_constructor_sets_roles() public view {
+        assertEq(anchor.owner(), owner);
+        assertEq(anchor.committer(), committer);
+        assertEq(anchor.count(), 0);
+    }
+
+    function test_constructor_rejects_zero_committer() public {
+        vm.expectRevert(AuditAnchor.ZeroAddress.selector);
+        new AuditAnchor(address(0));
+    }
+
+    function test_commit_emits_event() public {
+        vm.roll(100);
+        vm.expectEmit(true, true, true, true);
+        emit AuditAnchored(0, 1, ROOT_1, 100, 1_700_000_000);
+        vm.prank(committer);
+        uint256 id = anchor.commit(1, ROOT_1, 1_700_000_000);
+        assertEq(id, 0);
+    }
+
+    function test_commit_records_anchor() public {
+        vm.roll(123);
+        vm.prank(committer);
+        anchor.commit(7, ROOT_1, 1_700_000_000);
+
+        AuditAnchor.Anchor memory got = anchor.latest();
+        assertEq(got.treeSize, 7);
+        assertEq(got.root, ROOT_1);
+        assertEq(got.timestamp, 1_700_000_000);
+        assertEq(got.blockNumber, 123);
+        assertEq(anchor.count(), 1);
+    }
+
+    function test_commit_rejects_non_committer() public {
+        vm.prank(mallory);
+        vm.expectRevert(AuditAnchor.NotCommitter.selector);
+        anchor.commit(1, ROOT_1, 1);
+    }
+
+    function test_commit_rejects_empty_tree() public {
+        vm.prank(committer);
+        vm.expectRevert(AuditAnchor.EmptyTree.selector);
+        anchor.commit(0, ROOT_1, 1);
+    }
+
+    function test_commit_rejects_shrinking_tree() public {
+        vm.prank(committer);
+        anchor.commit(10, ROOT_1, 1);
+        vm.prank(committer);
+        vm.expectRevert(abi.encodeWithSelector(AuditAnchor.TreeShrank.selector, uint64(10), uint64(9)));
+        anchor.commit(9, ROOT_2, 2);
+    }
+
+    function test_commit_rejects_equal_tree() public {
+        vm.prank(committer);
+        anchor.commit(10, ROOT_1, 1);
+        vm.prank(committer);
+        vm.expectRevert(abi.encodeWithSelector(AuditAnchor.TreeShrank.selector, uint64(10), uint64(10)));
+        anchor.commit(10, ROOT_1, 2);
+    }
+
+    function test_anchorAt_returns_history() public {
+        vm.prank(committer);
+        anchor.commit(1, ROOT_1, 1);
+        vm.prank(committer);
+        anchor.commit(2, ROOT_2, 2);
+        AuditAnchor.Anchor memory a0 = anchor.anchorAt(0);
+        AuditAnchor.Anchor memory a1 = anchor.anchorAt(1);
+        assertEq(a0.root, ROOT_1);
+        assertEq(a1.root, ROOT_2);
+    }
+
+    function test_latest_reverts_when_empty() public {
+        vm.expectRevert(AuditAnchor.EmptyTree.selector);
+        anchor.latest();
+    }
+
+    function test_setCommitter_owner_only() public {
+        address next = address(0xCAFE);
+        vm.prank(mallory);
+        vm.expectRevert(AuditAnchor.NotOwner.selector);
+        anchor.setCommitter(next);
+
+        vm.prank(owner);
+        anchor.setCommitter(next);
+        assertEq(anchor.committer(), next);
+    }
+
+    function test_setCommitter_rejects_zero() public {
+        vm.prank(owner);
+        vm.expectRevert(AuditAnchor.ZeroAddress.selector);
+        anchor.setCommitter(address(0));
+    }
+
+    function test_two_step_ownership() public {
+        address next = address(0xFEED);
+        vm.prank(owner);
+        anchor.transferOwnership(next);
+        assertEq(anchor.pendingOwner(), next);
+        // Old owner is still owner until acceptance.
+        assertEq(anchor.owner(), owner);
+
+        // Wrong sender cannot accept.
+        vm.prank(mallory);
+        vm.expectRevert(AuditAnchor.NotPendingOwner.selector);
+        anchor.acceptOwnership();
+
+        vm.prank(next);
+        anchor.acceptOwnership();
+        assertEq(anchor.owner(), next);
+        assertEq(anchor.pendingOwner(), address(0));
+    }
+
+    function test_committer_cannot_self_promote() public {
+        vm.prank(committer);
+        vm.expectRevert(AuditAnchor.NotOwner.selector);
+        anchor.setCommitter(committer);
+    }
+}

--- a/contracts/test/AuditAnchor.t.sol
+++ b/contracts/test/AuditAnchor.t.sol
@@ -17,6 +17,9 @@ contract AuditAnchorTest is Test {
     event AuditAnchored(
         uint256 indexed id, uint64 treeSize, bytes32 indexed root, uint64 blockNumber, uint64 timestamp
     );
+    event CommitterChanged(address indexed previous, address indexed next);
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     function setUp() public {
         vm.prank(owner);
@@ -140,5 +143,32 @@ contract AuditAnchorTest is Test {
         vm.prank(committer);
         vm.expectRevert(AuditAnchor.NotOwner.selector);
         anchor.setCommitter(committer);
+    }
+
+    function test_setCommitter_emits_event() public {
+        address next = address(0xCAFE);
+        vm.expectEmit(true, true, true, true);
+        emit CommitterChanged(committer, next);
+        vm.prank(owner);
+        anchor.setCommitter(next);
+    }
+
+    function test_transferOwnership_emits_event() public {
+        address next = address(0xFEED);
+        vm.expectEmit(true, true, true, true);
+        emit OwnershipTransferStarted(owner, next);
+        vm.prank(owner);
+        anchor.transferOwnership(next);
+    }
+
+    function test_acceptOwnership_emits_event() public {
+        address next = address(0xFEED);
+        vm.prank(owner);
+        anchor.transferOwnership(next);
+
+        vm.expectEmit(true, true, true, true);
+        emit OwnershipTransferred(owner, next);
+        vm.prank(next);
+        anchor.acceptOwnership();
     }
 }

--- a/go-key-service/cmd/keyserver/main.go
+++ b/go-key-service/cmd/keyserver/main.go
@@ -113,7 +113,7 @@ func buildAnchorClient(cfg config.Config) (anchor.EVMClient, error) {
 		return anchor.NewCastClient(anchor.CastClientConfig{
 			ContractAddress: cfg.AnchorContractAddress,
 			RPCURL:          cfg.AnchorRPCURL,
-			PrivateKey:      cfg.AnchorPrivateKey,
+			PrivateKey:      cfg.AnchorPrivateKey.Reveal(),
 			CastBinary:      cfg.AnchorCastBinary,
 		})
 	default:

--- a/go-key-service/cmd/keyserver/main.go
+++ b/go-key-service/cmd/keyserver/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/anchor"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/capability"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/config"
@@ -28,7 +29,7 @@ func main() {
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.LogLevel}))
 	slog.SetDefault(logger)
-	logger.Info("starting", "addr", cfg.Addr, "schema_version", action.SchemaVersion)
+	logger.Info("starting", "addr", cfg.Addr, "schema_version", action.SchemaVersion, "anchor_mode", cfg.AnchorMode)
 
 	store := keystore.NewMemory()
 	tree := merkle.New()
@@ -38,13 +39,38 @@ func main() {
 		logger.Error("capability", "err", err)
 		os.Exit(1)
 	}
+
+	apiServer := httpapi.NewServer(store, logger).
+		WithAuditPipeline(pipeline).
+		WithCapability(capSvc)
+
+	var committer *anchor.Committer
+	if cfg.AnchorMode != config.AnchorOff {
+		client, err := buildAnchorClient(cfg)
+		if err != nil {
+			logger.Error("anchor client", "err", err)
+			os.Exit(1)
+		}
+		latest := anchor.NewLatestStore()
+		committer, err = anchor.NewCommitter(tree, client, latest, anchor.CommitterOptions{
+			Interval: cfg.AnchorInterval,
+			Logger:   logger,
+		})
+		if err != nil {
+			logger.Error("anchor committer", "err", err)
+			os.Exit(1)
+		}
+		apiServer = apiServer.WithAnchor(latest)
+	}
+
 	srv := &http.Server{
-		Addr: cfg.Addr,
-		Handler: httpapi.NewServer(store, logger).
-			WithAuditPipeline(pipeline).
-			WithCapability(capSvc).
-			Router(),
+		Addr:              cfg.Addr,
+		Handler:           apiServer.Router(),
 		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	if committer != nil {
+		committer.Start(context.Background())
 	}
 
 	errCh := make(chan error, 1)
@@ -65,10 +91,32 @@ func main() {
 		os.Exit(1)
 	}
 
+	if committer != nil {
+		if !committer.Stop(5 * time.Second) {
+			logger.Warn("anchor committer did not stop cleanly")
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
 		logger.Error("shutdown", "err", err)
 		os.Exit(1)
+	}
+}
+
+func buildAnchorClient(cfg config.Config) (anchor.EVMClient, error) {
+	switch cfg.AnchorMode {
+	case config.AnchorDryRun:
+		return anchor.NewFakeEVMClient(), nil
+	case config.AnchorCast:
+		return anchor.NewCastClient(anchor.CastClientConfig{
+			ContractAddress: cfg.AnchorContractAddress,
+			RPCURL:          cfg.AnchorRPCURL,
+			PrivateKey:      cfg.AnchorPrivateKey,
+			CastBinary:      cfg.AnchorCastBinary,
+		})
+	default:
+		return nil, errors.New("buildAnchorClient: unsupported anchor mode")
 	}
 }

--- a/go-key-service/internal/anchor/anchor.go
+++ b/go-key-service/internal/anchor/anchor.go
@@ -1,0 +1,137 @@
+// Package anchor periodically commits the Merkle audit-log head to an
+// on-chain witness contract (contracts/src/AuditAnchor.sol).
+//
+// Two pieces live here. The first is a small abstract EVMClient
+// interface that the broadcaster speaks; the production binary wires
+// it to a foundry `cast send` shell-out (see CastClient) so we do not
+// pull go-ethereum into go.mod. The second is the Committer, a
+// goroutine that polls a TreeView every Interval and submits a new
+// (size, root, ts) tuple iff the tree has grown since the last
+// successful commit. The contract enforces the same monotonicity
+// constraint, so a duplicate commit on retry just reverts harmlessly.
+//
+// The Indexer is the read side: it stores the most recent commit in
+// memory so the dashboard can read it via GET /v1/anchor/latest
+// without a fresh RPC round-trip.
+package anchor
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// HashSize is the length, in bytes, of the Merkle root we anchor.
+// Mirrors merkle.HashSize; redeclared here so this package has no
+// hard dependency on merkle.
+const HashSize = 32
+
+// Anchor is one (size, root) tuple committed on chain. The contract
+// returns the same shape from `latest()` / `anchorAt(id)`.
+type Anchor struct {
+	ID          uint64    `json:"id"`
+	TreeSize    uint64    `json:"tree_size"`
+	Root        []byte    `json:"root"`
+	Timestamp   time.Time `json:"timestamp"`
+	BlockNumber uint64    `json:"block_number,omitempty"`
+	TxHash      string    `json:"tx_hash,omitempty"`
+}
+
+// RootHex returns the 0x-prefixed hex string of the root, the form the
+// contract expects in calldata and the indexer returns to the dashboard.
+func (a Anchor) RootHex() string {
+	return "0x" + hex.EncodeToString(a.Root)
+}
+
+// TreeView is the producer side: anything that can report the current
+// (size, root) of the live Merkle tree. Implemented by *merkle.Tree
+// directly (Size + Root); kept as an interface so tests can drive the
+// committer with canned values.
+type TreeView interface {
+	Size() uint64
+	Root() []byte
+}
+
+// EVMClient is the broadcaster contract. Real impls turn the call into
+// an Ethereum transaction; the in-memory FakeEVMClient just records
+// the calls for tests. Returning the on-chain id of the new anchor lets
+// the committer correlate with `AuditAnchored(id, ...)` events later.
+type EVMClient interface {
+	// Commit submits (treeSize, root, ts) to AuditAnchor.commit. The
+	// returned receipt carries the new anchor id and tx metadata when
+	// the impl can produce them; a Noop/Cast impl may leave them zero.
+	Commit(ctx context.Context, treeSize uint64, root []byte, ts time.Time) (CommitReceipt, error)
+}
+
+// CommitReceipt is the post-broadcast shape an EVMClient hands back.
+type CommitReceipt struct {
+	ID          uint64
+	TxHash      string
+	BlockNumber uint64
+}
+
+// Sentinel errors returned by Committer / EVMClient impls.
+var (
+	ErrTreeShrank   = errors.New("anchor: tree size did not grow since last commit")
+	ErrInvalidRoot  = errors.New("anchor: root must be 32 bytes")
+	ErrEmptyTree    = errors.New("anchor: tree is empty")
+	ErrNoAnchorYet  = errors.New("anchor: no commit recorded yet")
+	ErrCommitFailed = errors.New("anchor: commit failed")
+)
+
+// validateCommit centralises the basic sanity checks both the
+// committer and the FakeEVMClient run before recording an anchor.
+// Mirrors the contract's `EmptyTree` / `TreeShrank` reverts so unit
+// tests can fail fast without a full chain round-trip.
+func validateCommit(treeSize uint64, root []byte) error {
+	if treeSize == 0 {
+		return ErrEmptyTree
+	}
+	if len(root) != HashSize {
+		return ErrInvalidRoot
+	}
+	return nil
+}
+
+// LatestStore is the read-side cache the indexer hands to the HTTP
+// handler. The committer writes here on every successful broadcast;
+// the handler reads via Latest().
+type LatestStore struct {
+	mu     sync.RWMutex
+	latest *Anchor
+}
+
+func NewLatestStore() *LatestStore { return &LatestStore{} }
+
+// Set replaces the cached anchor. Safe for concurrent use.
+func (s *LatestStore) Set(a Anchor) {
+	cp := a
+	if a.Root != nil {
+		cp.Root = append([]byte(nil), a.Root...)
+	}
+	s.mu.Lock()
+	s.latest = &cp
+	s.mu.Unlock()
+}
+
+// Latest returns the most recent anchor or ErrNoAnchorYet if the
+// committer has not yet succeeded.
+func (s *LatestStore) Latest() (Anchor, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.latest == nil {
+		return Anchor{}, ErrNoAnchorYet
+	}
+	cp := *s.latest
+	if s.latest.Root != nil {
+		cp.Root = append([]byte(nil), s.latest.Root...)
+	}
+	return cp, nil
+}
+
+func formatErr(err error, treeSize uint64, root []byte) error {
+	return fmt.Errorf("%w: size=%d root=%s: %v", ErrCommitFailed, treeSize, hex.EncodeToString(root), err)
+}

--- a/go-key-service/internal/anchor/anchor.go
+++ b/go-key-service/internal/anchor/anchor.go
@@ -47,12 +47,13 @@ func (a Anchor) RootHex() string {
 }
 
 // TreeView is the producer side: anything that can report the current
-// (size, root) of the live Merkle tree. Implemented by *merkle.Tree
-// directly (Size + Root); kept as an interface so tests can drive the
-// committer with canned values.
+// (size, root) of the live Merkle tree atomically. Implemented by
+// *merkle.Tree directly (Snapshot); kept as an interface so tests can
+// drive the committer with canned values. Snapshot must return both
+// fields under the same lock — committing a size that doesn't match
+// the root corrupts the on-chain audit trail.
 type TreeView interface {
-	Size() uint64
-	Root() []byte
+	Snapshot() (size uint64, root []byte)
 }
 
 // EVMClient is the broadcaster contract. Real impls turn the call into

--- a/go-key-service/internal/anchor/cast_parse.go
+++ b/go-key-service/internal/anchor/cast_parse.go
@@ -1,0 +1,49 @@
+package anchor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseCastSendOutput pulls the bits we care about out of `cast send
+// --json`. The receipt shape is the standard JSON-RPC eth_getTransactionReceipt
+// payload, with hex-encoded uint fields.
+//
+// We do not import go-ethereum just to decode this — the field set is
+// stable and small.
+func parseCastSendOutput(raw []byte) (CommitReceipt, error) {
+	var r struct {
+		TransactionHash string `json:"transactionHash"`
+		BlockNumber     string `json:"blockNumber"`
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return CommitReceipt{}, fmt.Errorf("decode json: %w", err)
+	}
+	if r.TransactionHash == "" {
+		return CommitReceipt{}, fmt.Errorf("receipt missing transactionHash")
+	}
+	bn, err := parseHexUint(r.BlockNumber)
+	if err != nil {
+		return CommitReceipt{}, fmt.Errorf("blockNumber: %w", err)
+	}
+	return CommitReceipt{
+		TxHash:      r.TransactionHash,
+		BlockNumber: bn,
+	}, nil
+}
+
+// parseHexUint accepts "0x1a" or "26" and returns 26. cast usually
+// emits 0x-prefixed hex but tests/older versions sometimes emit
+// decimal — handle both.
+func parseHexUint(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return strconv.ParseUint(s[2:], 16, 64)
+	}
+	return strconv.ParseUint(s, 10, 64)
+}

--- a/go-key-service/internal/anchor/client.go
+++ b/go-key-service/internal/anchor/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -84,16 +85,21 @@ func (f *FakeEVMClient) Commit(_ context.Context, treeSize uint64, root []byte, 
 // the process env at construction time so the broadcaster never logs
 // the private key.
 //
+// The private key is passed to `cast` via the ETH_PRIVATE_KEY env var
+// (which `cast send` accepts as a fallback when --private-key is
+// absent), not via the command line. That keeps the secret out of
+// `ps aux`, /proc/<pid>/cmdline, and shell history files.
+//
 // The contract ABI we target:
 //
 //	function commit(uint64 treeSize, bytes32 root, uint64 timestamp)
 //	    external returns (uint256 id);
 type CastClient struct {
-	contract     string // 0x… address of the deployed AuditAnchor
-	rpcURL       string
-	privateKey   string // hex (0x-prefixed); never logged
-	castBin      string // path to `cast` binary; "cast" if on PATH
-	commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+	contract      string // 0x… address of the deployed AuditAnchor
+	rpcURL        string
+	privateKey    string // hex (0x-prefixed); never logged or argv-passed
+	castBin       string // path to `cast` binary; "cast" if on PATH
+	commandRunner func(ctx context.Context, env []string, name string, args ...string) ([]byte, error)
 }
 
 // CastClientConfig carries the wiring CastClient needs.
@@ -138,19 +144,25 @@ func (c *CastClient) Commit(ctx context.Context, treeSize uint64, root []byte, t
 	if err := validateCommit(treeSize, root); err != nil {
 		return CommitReceipt{}, err
 	}
+	unix := ts.Unix()
+	if unix < 0 {
+		return CommitReceipt{}, fmt.Errorf("anchor: timestamp before unix epoch (%d)", unix)
+	}
 	rootHex := "0x" + hex.EncodeToString(root)
 	args := []string{
 		"send",
 		"--rpc-url", c.rpcURL,
-		"--private-key", c.privateKey,
 		"--json",
 		c.contract,
 		"commit(uint64,bytes32,uint64)",
 		strconv.FormatUint(treeSize, 10),
 		rootHex,
-		strconv.FormatInt(ts.Unix(), 10),
+		strconv.FormatUint(uint64(unix), 10),
 	}
-	out, err := c.commandRunner(ctx, c.castBin, args...)
+	// cast reads ETH_PRIVATE_KEY when --private-key is absent. Passing
+	// it via env keeps the secret out of /proc/<pid>/cmdline.
+	env := []string{"ETH_PRIVATE_KEY=" + c.privateKey}
+	out, err := c.commandRunner(ctx, env, c.castBin, args...)
 	if err != nil {
 		return CommitReceipt{}, fmt.Errorf("cast send: %w (output: %s)", err, strings.TrimSpace(string(out)))
 	}
@@ -161,6 +173,11 @@ func (c *CastClient) Commit(ctx context.Context, treeSize uint64, root []byte, t
 	return receipt, nil
 }
 
-func defaultCastRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+func defaultCastRunner(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	// Inherit the parent env so cast still sees PATH, HOME, etc., but
+	// override / add the secret-bearing entries from `env` last so
+	// they take precedence over anything inherited.
+	cmd.Env = append(append([]string(nil), os.Environ()...), env...)
+	return cmd.CombinedOutput()
 }

--- a/go-key-service/internal/anchor/client.go
+++ b/go-key-service/internal/anchor/client.go
@@ -1,0 +1,166 @@
+package anchor
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// FakeEVMClient is the in-memory EVMClient used by tests and by the
+// keyserver in `--anchor-mode=dry-run`. It enforces the same
+// monotonicity invariant the contract does so the dashboard shows the
+// same shape locally as it does on Sepolia.
+type FakeEVMClient struct {
+	mu       sync.Mutex
+	anchors  []Anchor
+	nextID   uint64
+	failNext error
+	calls    atomic.Int64
+}
+
+// NewFakeEVMClient returns an empty FakeEVMClient.
+func NewFakeEVMClient() *FakeEVMClient { return &FakeEVMClient{} }
+
+// SetNextError makes the next Commit call return err. One-shot; the
+// arming clears after the call returns.
+func (f *FakeEVMClient) SetNextError(err error) {
+	f.mu.Lock()
+	f.failNext = err
+	f.mu.Unlock()
+}
+
+// Calls returns how many times Commit has been invoked. Useful for
+// asserting "exactly one commit per growing tick".
+func (f *FakeEVMClient) Calls() int64 { return f.calls.Load() }
+
+// Anchors returns a copy of the recorded anchors in order.
+func (f *FakeEVMClient) Anchors() []Anchor {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Anchor, len(f.anchors))
+	copy(out, f.anchors)
+	return out
+}
+
+// Commit implements EVMClient. Stores the anchor in memory; returns a
+// synthetic receipt with a monotonic id and a zero block number.
+func (f *FakeEVMClient) Commit(_ context.Context, treeSize uint64, root []byte, ts time.Time) (CommitReceipt, error) {
+	f.calls.Add(1)
+	if err := validateCommit(treeSize, root); err != nil {
+		return CommitReceipt{}, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.failNext; err != nil {
+		f.failNext = nil
+		return CommitReceipt{}, err
+	}
+	if n := len(f.anchors); n > 0 && treeSize <= f.anchors[n-1].TreeSize {
+		return CommitReceipt{}, fmt.Errorf("%w: %d <= last %d", ErrTreeShrank, treeSize, f.anchors[n-1].TreeSize)
+	}
+	id := f.nextID
+	f.nextID++
+	a := Anchor{
+		ID:        id,
+		TreeSize:  treeSize,
+		Root:      append([]byte(nil), root...),
+		Timestamp: ts,
+		TxHash:    fmt.Sprintf("0xfake%016x", id),
+	}
+	f.anchors = append(f.anchors, a)
+	return CommitReceipt{ID: id, TxHash: a.TxHash}, nil
+}
+
+// CastClient is the production EVMClient: it shells out to the
+// foundry `cast send` binary so the Go service does not have to pull
+// go-ethereum into its dependency closure. Configuration is read from
+// the process env at construction time so the broadcaster never logs
+// the private key.
+//
+// The contract ABI we target:
+//
+//	function commit(uint64 treeSize, bytes32 root, uint64 timestamp)
+//	    external returns (uint256 id);
+type CastClient struct {
+	contract     string // 0x… address of the deployed AuditAnchor
+	rpcURL       string
+	privateKey   string // hex (0x-prefixed); never logged
+	castBin      string // path to `cast` binary; "cast" if on PATH
+	commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// CastClientConfig carries the wiring CastClient needs.
+type CastClientConfig struct {
+	ContractAddress string
+	RPCURL          string
+	PrivateKey      string
+	CastBinary      string // optional override; defaults to "cast"
+}
+
+// NewCastClient validates config and returns a ready client. It does
+// not exec anything; the first network round-trip happens on Commit.
+func NewCastClient(cfg CastClientConfig) (*CastClient, error) {
+	if cfg.ContractAddress == "" {
+		return nil, errors.New("anchor: ContractAddress is required")
+	}
+	if cfg.RPCURL == "" {
+		return nil, errors.New("anchor: RPCURL is required")
+	}
+	if cfg.PrivateKey == "" {
+		return nil, errors.New("anchor: PrivateKey is required")
+	}
+	bin := cfg.CastBinary
+	if bin == "" {
+		bin = "cast"
+	}
+	return &CastClient{
+		contract:      cfg.ContractAddress,
+		rpcURL:        cfg.RPCURL,
+		privateKey:    cfg.PrivateKey,
+		castBin:       bin,
+		commandRunner: defaultCastRunner,
+	}, nil
+}
+
+// Commit broadcasts a `commit(treeSize, root, ts)` transaction via
+// `cast send` and parses the resulting JSON receipt for the tx hash
+// and block number. The on-chain anchor id is read back from the
+// `AuditAnchored` event the contract emits — for the demo we settle
+// for the receipt-derived id by querying anchor count after the fact.
+func (c *CastClient) Commit(ctx context.Context, treeSize uint64, root []byte, ts time.Time) (CommitReceipt, error) {
+	if err := validateCommit(treeSize, root); err != nil {
+		return CommitReceipt{}, err
+	}
+	rootHex := "0x" + hex.EncodeToString(root)
+	args := []string{
+		"send",
+		"--rpc-url", c.rpcURL,
+		"--private-key", c.privateKey,
+		"--json",
+		c.contract,
+		"commit(uint64,bytes32,uint64)",
+		strconv.FormatUint(treeSize, 10),
+		rootHex,
+		strconv.FormatInt(ts.Unix(), 10),
+	}
+	out, err := c.commandRunner(ctx, c.castBin, args...)
+	if err != nil {
+		return CommitReceipt{}, fmt.Errorf("cast send: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	receipt, err := parseCastSendOutput(out)
+	if err != nil {
+		return CommitReceipt{}, fmt.Errorf("cast send: parse receipt: %w", err)
+	}
+	return receipt, nil
+}
+
+func defaultCastRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}

--- a/go-key-service/internal/anchor/client_test.go
+++ b/go-key-service/internal/anchor/client_test.go
@@ -1,0 +1,192 @@
+package anchor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFakeEVMClient_RecordsCalls(t *testing.T) {
+	c := NewFakeEVMClient()
+	root := newRoot(0xa1)
+	r, err := c.Commit(context.Background(), 1, root, time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if r.ID != 0 {
+		t.Errorf("first id should be 0, got %d", r.ID)
+	}
+	if r.TxHash == "" {
+		t.Errorf("synthetic tx hash should be set")
+	}
+	if got := c.Calls(); got != 1 {
+		t.Errorf("call counter: got %d want 1", got)
+	}
+}
+
+func TestFakeEVMClient_MonotonicEnforced(t *testing.T) {
+	c := NewFakeEVMClient()
+	root := newRoot(0xa1)
+	if _, err := c.Commit(context.Background(), 5, root, time.Unix(1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Commit(context.Background(), 4, root, time.Unix(2, 0)); !errors.Is(err, ErrTreeShrank) {
+		t.Errorf("expected ErrTreeShrank, got %v", err)
+	}
+	if _, err := c.Commit(context.Background(), 5, root, time.Unix(2, 0)); !errors.Is(err, ErrTreeShrank) {
+		t.Errorf("equal-size commit should also shrink, got %v", err)
+	}
+}
+
+func TestFakeEVMClient_InvalidInputs(t *testing.T) {
+	c := NewFakeEVMClient()
+	if _, err := c.Commit(context.Background(), 0, newRoot(0xa1), time.Now()); !errors.Is(err, ErrEmptyTree) {
+		t.Errorf("expected ErrEmptyTree, got %v", err)
+	}
+	if _, err := c.Commit(context.Background(), 1, []byte{0x1}, time.Now()); !errors.Is(err, ErrInvalidRoot) {
+		t.Errorf("expected ErrInvalidRoot, got %v", err)
+	}
+}
+
+func TestFakeEVMClient_OneShotErrorClears(t *testing.T) {
+	c := NewFakeEVMClient()
+	want := errors.New("network down")
+	c.SetNextError(want)
+	if _, err := c.Commit(context.Background(), 1, newRoot(0xa1), time.Now()); !errors.Is(err, want) {
+		t.Errorf("expected armed error, got %v", err)
+	}
+	// Second call should succeed — the arming is one-shot.
+	if _, err := c.Commit(context.Background(), 2, newRoot(0xa1), time.Now()); err != nil {
+		t.Errorf("expected success after one-shot error, got %v", err)
+	}
+}
+
+func TestNewCastClient_ValidatesConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  CastClientConfig
+	}{
+		{"missing contract", CastClientConfig{RPCURL: "http://x", PrivateKey: "0x1"}},
+		{"missing rpc", CastClientConfig{ContractAddress: "0xa", PrivateKey: "0x1"}},
+		{"missing key", CastClientConfig{ContractAddress: "0xa", RPCURL: "http://x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewCastClient(tc.cfg); err == nil {
+				t.Errorf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestCastClient_BuildsCommandAndParsesReceipt(t *testing.T) {
+	c, err := NewCastClient(CastClientConfig{
+		ContractAddress: "0xCAFE",
+		RPCURL:          "http://localhost:8545",
+		PrivateKey:      "0xab" + strings.Repeat("0", 62),
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	var got struct {
+		bin  string
+		args []string
+	}
+	c.commandRunner = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		got.bin = name
+		got.args = append(got.args, args...)
+		return []byte(`{"transactionHash":"0xdead","blockNumber":"0x1a"}`), nil
+	}
+
+	receipt, err := c.Commit(context.Background(), 7, newRoot(0xa1), time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if got.bin != "cast" {
+		t.Errorf("binary: got %q want cast", got.bin)
+	}
+	// First arg is the subcommand.
+	if got.args[0] != "send" {
+		t.Errorf("first arg: got %q want send", got.args[0])
+	}
+	// Last three args are the abi-encoded calldata.
+	n := len(got.args)
+	if got.args[n-4] != "commit(uint64,bytes32,uint64)" {
+		t.Errorf("function selector: got %q", got.args[n-4])
+	}
+	if got.args[n-3] != "7" {
+		t.Errorf("size arg: got %q want 7", got.args[n-3])
+	}
+	if got.args[n-2] != "0x"+strings.Repeat("a1", 32) {
+		t.Errorf("root arg: got %q", got.args[n-2])
+	}
+	if got.args[n-1] != "1700000000" {
+		t.Errorf("ts arg: got %q want 1700000000", got.args[n-1])
+	}
+	if receipt.TxHash != "0xdead" {
+		t.Errorf("tx hash: got %q", receipt.TxHash)
+	}
+	if receipt.BlockNumber != 26 {
+		t.Errorf("block number: got %d want 26", receipt.BlockNumber)
+	}
+}
+
+func TestCastClient_RejectsBadInputs(t *testing.T) {
+	c, _ := NewCastClient(CastClientConfig{
+		ContractAddress: "0xCAFE",
+		RPCURL:          "http://localhost:8545",
+		PrivateKey:      "0xab",
+	})
+	c.commandRunner = func(context.Context, string, ...string) ([]byte, error) {
+		t.Fatal("commandRunner should not be invoked on validation failure")
+		return nil, nil
+	}
+	if _, err := c.Commit(context.Background(), 0, newRoot(0xa1), time.Now()); !errors.Is(err, ErrEmptyTree) {
+		t.Errorf("expected ErrEmptyTree, got %v", err)
+	}
+	if _, err := c.Commit(context.Background(), 1, []byte{0x1}, time.Now()); !errors.Is(err, ErrInvalidRoot) {
+		t.Errorf("expected ErrInvalidRoot, got %v", err)
+	}
+}
+
+func TestCastClient_SurfacesCastFailure(t *testing.T) {
+	c, _ := NewCastClient(CastClientConfig{
+		ContractAddress: "0xCAFE",
+		RPCURL:          "http://localhost:8545",
+		PrivateKey:      "0xab",
+	})
+	c.commandRunner = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("revert: TreeShrank"), errors.New("exit 1")
+	}
+	_, err := c.Commit(context.Background(), 1, newRoot(0xa1), time.Now())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "TreeShrank") {
+		t.Errorf("error should include cast output: %v", err)
+	}
+}
+
+func TestParseCastSendOutput_HandlesDecimalBlockNumber(t *testing.T) {
+	r, err := parseCastSendOutput([]byte(`{"transactionHash":"0xab","blockNumber":"42"}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if r.BlockNumber != 42 {
+		t.Errorf("block number: got %d want 42", r.BlockNumber)
+	}
+}
+
+func TestParseCastSendOutput_RejectsMissingHash(t *testing.T) {
+	if _, err := parseCastSendOutput([]byte(`{"blockNumber":"0x1"}`)); err == nil {
+		t.Fatal("expected error on missing tx hash")
+	}
+}
+
+func TestParseCastSendOutput_RejectsBadJSON(t *testing.T) {
+	if _, err := parseCastSendOutput([]byte("not json")); err == nil {
+		t.Fatal("expected error on bad json")
+	}
+}

--- a/go-key-service/internal/anchor/client_test.go
+++ b/go-key-service/internal/anchor/client_test.go
@@ -93,10 +93,12 @@ func TestCastClient_BuildsCommandAndParsesReceipt(t *testing.T) {
 	var got struct {
 		bin  string
 		args []string
+		env  []string
 	}
-	c.commandRunner = func(_ context.Context, name string, args ...string) ([]byte, error) {
+	c.commandRunner = func(_ context.Context, env []string, name string, args ...string) ([]byte, error) {
 		got.bin = name
 		got.args = append(got.args, args...)
+		got.env = append(got.env, env...)
 		return []byte(`{"transactionHash":"0xdead","blockNumber":"0x1a"}`), nil
 	}
 
@@ -110,6 +112,23 @@ func TestCastClient_BuildsCommandAndParsesReceipt(t *testing.T) {
 	// First arg is the subcommand.
 	if got.args[0] != "send" {
 		t.Errorf("first arg: got %q want send", got.args[0])
+	}
+	// Private key must NOT appear on the command line.
+	for _, a := range got.args {
+		if strings.Contains(a, c.privateKey) || a == "--private-key" {
+			t.Errorf("private key leaked into argv: %q", a)
+		}
+	}
+	// It must be passed via ETH_PRIVATE_KEY env instead.
+	wantEnv := "ETH_PRIVATE_KEY=" + c.privateKey
+	found := false
+	for _, e := range got.env {
+		if e == wantEnv {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ETH_PRIVATE_KEY not passed via env: %v", got.env)
 	}
 	// Last three args are the abi-encoded calldata.
 	n := len(got.args)
@@ -139,7 +158,7 @@ func TestCastClient_RejectsBadInputs(t *testing.T) {
 		RPCURL:          "http://localhost:8545",
 		PrivateKey:      "0xab",
 	})
-	c.commandRunner = func(context.Context, string, ...string) ([]byte, error) {
+	c.commandRunner = func(context.Context, []string, string, ...string) ([]byte, error) {
 		t.Fatal("commandRunner should not be invoked on validation failure")
 		return nil, nil
 	}
@@ -151,13 +170,30 @@ func TestCastClient_RejectsBadInputs(t *testing.T) {
 	}
 }
 
+func TestCastClient_RejectsNegativeTimestamp(t *testing.T) {
+	c, _ := NewCastClient(CastClientConfig{
+		ContractAddress: "0xCAFE",
+		RPCURL:          "http://localhost:8545",
+		PrivateKey:      "0xab",
+	})
+	c.commandRunner = func(context.Context, []string, string, ...string) ([]byte, error) {
+		t.Fatal("commandRunner should not be invoked on negative ts")
+		return nil, nil
+	}
+	preEpoch := time.Date(1969, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := c.Commit(context.Background(), 1, newRoot(0xa1), preEpoch)
+	if err == nil || !strings.Contains(err.Error(), "before unix epoch") {
+		t.Errorf("expected pre-epoch error, got %v", err)
+	}
+}
+
 func TestCastClient_SurfacesCastFailure(t *testing.T) {
 	c, _ := NewCastClient(CastClientConfig{
 		ContractAddress: "0xCAFE",
 		RPCURL:          "http://localhost:8545",
 		PrivateKey:      "0xab",
 	})
-	c.commandRunner = func(context.Context, string, ...string) ([]byte, error) {
+	c.commandRunner = func(context.Context, []string, string, ...string) ([]byte, error) {
 		return []byte("revert: TreeShrank"), errors.New("exit 1")
 	}
 	_, err := c.Commit(context.Background(), 1, newRoot(0xa1), time.Now())

--- a/go-key-service/internal/anchor/committer.go
+++ b/go-key-service/internal/anchor/committer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -32,8 +33,10 @@ type Committer struct {
 
 	lastCommitted atomic.Uint64
 
-	stop chan struct{}
-	done chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stop      chan struct{}
+	done      chan struct{}
 }
 
 // CommitterOptions configures a Committer; zero values get sensible
@@ -83,16 +86,20 @@ func NewCommitter(tree TreeView, client EVMClient, store *LatestStore, opts Comm
 	}, nil
 }
 
-// Start launches the polling goroutine. Calling Start more than once
-// panics — committers are not reusable.
+// Start launches the polling goroutine. Idempotent: subsequent calls
+// are no-ops, so wiring code that fans Start out to multiple lifecycle
+// hooks won't spawn rogue committers.
 func (c *Committer) Start(ctx context.Context) {
-	go c.loop(ctx)
+	c.startOnce.Do(func() {
+		go c.loop(ctx)
+	})
 }
 
 // Stop signals the loop to exit and waits up to `timeout` for the
-// goroutine to drain. Returns true on clean exit.
+// goroutine to drain. Returns true on clean exit. Idempotent: a
+// retried Stop after a timeout will not panic on a closed channel.
 func (c *Committer) Stop(timeout time.Duration) bool {
-	close(c.stop)
+	c.stopOnce.Do(func() { close(c.stop) })
 	select {
 	case <-c.done:
 		return true
@@ -141,11 +148,12 @@ func (c *Committer) loop(ctx context.Context) {
 // ErrEmptyTree are returned (not logged) so the caller can treat them
 // as non-events.
 func (c *Committer) commit(ctx context.Context) (Anchor, bool, error) {
-	size := c.tree.Size()
-	if size == 0 {
+	rawSize, rawRoot := c.tree.Snapshot()
+	if rawSize == 0 {
 		return Anchor{}, false, ErrEmptyTree
 	}
-	root := append([]byte(nil), c.tree.Root()...)
+	size := rawSize
+	root := append([]byte(nil), rawRoot...)
 	if err := validateCommit(size, root); err != nil {
 		return Anchor{}, false, err
 	}

--- a/go-key-service/internal/anchor/committer.go
+++ b/go-key-service/internal/anchor/committer.go
@@ -1,0 +1,179 @@
+package anchor
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"time"
+)
+
+// Committer is the periodic poll-and-broadcast loop. Construct with
+// NewCommitter, then Start; Stop blocks until the goroutine exits.
+//
+// On every tick the committer:
+//
+//  1. Reads (size, root) from the live tree.
+//  2. Skips if size has not grown since the last successful commit.
+//  3. Calls EVMClient.Commit. On success, updates LatestStore. On
+//     failure, logs and retries on the next tick — no exponential
+//     back-off, on the assumption that 15 min ticks already are the
+//     back-off.
+//
+// The committer never blocks the audit-log append path; the tree is
+// only ever read.
+type Committer struct {
+	tree     TreeView
+	client   EVMClient
+	store    *LatestStore
+	interval time.Duration
+	clock    func() time.Time
+	logger   *slog.Logger
+
+	lastCommitted atomic.Uint64
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// CommitterOptions configures a Committer; zero values get sensible
+// defaults.
+type CommitterOptions struct {
+	// Interval between polls. Defaults to 15 minutes per issue #13.
+	Interval time.Duration
+	// Clock injected for tests. Defaults to time.Now.
+	Clock func() time.Time
+	// Logger injected for tests. Defaults to slog.Default.
+	Logger *slog.Logger
+}
+
+// NewCommitter validates required deps and returns a stopped committer.
+// Call Start to launch the goroutine.
+func NewCommitter(tree TreeView, client EVMClient, store *LatestStore, opts CommitterOptions) (*Committer, error) {
+	if tree == nil {
+		return nil, errors.New("anchor: tree is required")
+	}
+	if client == nil {
+		return nil, errors.New("anchor: evm client is required")
+	}
+	if store == nil {
+		return nil, errors.New("anchor: latest store is required")
+	}
+	interval := opts.Interval
+	if interval <= 0 {
+		interval = 15 * time.Minute
+	}
+	clock := opts.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Committer{
+		tree:     tree,
+		client:   client,
+		store:    store,
+		interval: interval,
+		clock:    clock,
+		logger:   logger,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Start launches the polling goroutine. Calling Start more than once
+// panics — committers are not reusable.
+func (c *Committer) Start(ctx context.Context) {
+	go c.loop(ctx)
+}
+
+// Stop signals the loop to exit and waits up to `timeout` for the
+// goroutine to drain. Returns true on clean exit.
+func (c *Committer) Stop(timeout time.Duration) bool {
+	close(c.stop)
+	select {
+	case <-c.done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// CommitOnce runs one pass without waiting for the next tick. Used by
+// the keyserver's `commit-now` admin endpoint and by tests that want a
+// deterministic single shot.
+func (c *Committer) CommitOnce(ctx context.Context) (Anchor, bool, error) {
+	return c.commit(ctx)
+}
+
+// LastCommittedSize is the size of the most recent successful commit.
+// 0 means we have not committed yet (or the tree is empty).
+func (c *Committer) LastCommittedSize() uint64 { return c.lastCommitted.Load() }
+
+func (c *Committer) loop(ctx context.Context) {
+	defer close(c.done)
+	t := time.NewTicker(c.interval)
+	defer t.Stop()
+	// Best-effort first commit so the dashboard isn't blank for the
+	// whole first interval. Failures here are logged and retried.
+	if _, _, err := c.commit(ctx); err != nil && !errors.Is(err, ErrTreeShrank) && !errors.Is(err, ErrEmptyTree) {
+		c.logger.Warn("anchor: initial commit failed", "err", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stop:
+			return
+		case <-t.C:
+			if _, _, err := c.commit(ctx); err != nil &&
+				!errors.Is(err, ErrTreeShrank) && !errors.Is(err, ErrEmptyTree) {
+				c.logger.Warn("anchor: tick commit failed", "err", err)
+			}
+		}
+	}
+}
+
+// commit is the unit of work: snapshot the tree, decide if we should
+// broadcast, broadcast, update the store. ErrTreeShrank and
+// ErrEmptyTree are returned (not logged) so the caller can treat them
+// as non-events.
+func (c *Committer) commit(ctx context.Context) (Anchor, bool, error) {
+	size := c.tree.Size()
+	if size == 0 {
+		return Anchor{}, false, ErrEmptyTree
+	}
+	root := append([]byte(nil), c.tree.Root()...)
+	if err := validateCommit(size, root); err != nil {
+		return Anchor{}, false, err
+	}
+	if last := c.lastCommitted.Load(); size <= last {
+		return Anchor{}, false, ErrTreeShrank
+	}
+	now := c.clock()
+	receipt, err := c.client.Commit(ctx, size, root, now)
+	if err != nil {
+		return Anchor{}, false, formatErr(err, size, root)
+	}
+	a := Anchor{
+		ID:          receipt.ID,
+		TreeSize:    size,
+		Root:        root,
+		Timestamp:   now,
+		BlockNumber: receipt.BlockNumber,
+		TxHash:      receipt.TxHash,
+	}
+	c.store.Set(a)
+	c.lastCommitted.Store(size)
+	c.logger.Info(
+		"anchor: committed",
+		"id", a.ID,
+		"tree_size", a.TreeSize,
+		"root_hex", a.RootHex(),
+		"tx_hash", a.TxHash,
+		"block_number", a.BlockNumber,
+	)
+	return a, true, nil
+}

--- a/go-key-service/internal/anchor/committer_test.go
+++ b/go-key-service/internal/anchor/committer_test.go
@@ -1,0 +1,207 @@
+package anchor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// fakeTree is a TreeView whose size and root are caller-controlled so
+// the committer can be exercised without spinning up a real RFC 6962
+// tree.
+type fakeTree struct {
+	size uint64
+	root []byte
+}
+
+func (f *fakeTree) Size() uint64 { return f.size }
+func (f *fakeTree) Root() []byte  { return f.root }
+
+func newRoot(b byte) []byte {
+	out := make([]byte, HashSize)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+func newCommitter(t *testing.T, tree TreeView, client EVMClient) (*Committer, *LatestStore) {
+	t.Helper()
+	store := NewLatestStore()
+	c, err := NewCommitter(tree, client, store, CommitterOptions{
+		Interval: time.Hour, // we drive ticks via CommitOnce in tests
+		Clock:    func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+		Logger:   slog.New(slog.NewTextHandler(new(bytes.Buffer), nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewCommitter: %v", err)
+	}
+	return c, store
+}
+
+func TestCommitOnce_SuccessUpdatesStore(t *testing.T) {
+	tree := &fakeTree{size: 5, root: newRoot(0xab)}
+	client := NewFakeEVMClient()
+	c, store := newCommitter(t, tree, client)
+
+	a, ok, err := c.CommitOnce(context.Background())
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected committed=true")
+	}
+	if a.TreeSize != 5 {
+		t.Errorf("tree size: got %d want 5", a.TreeSize)
+	}
+	if !bytes.Equal(a.Root, tree.root) {
+		t.Errorf("root mismatch: got %x want %x", a.Root, tree.root)
+	}
+	got, err := store.Latest()
+	if err != nil {
+		t.Fatalf("store.Latest: %v", err)
+	}
+	if got.TreeSize != 5 {
+		t.Errorf("store size: got %d want 5", got.TreeSize)
+	}
+	if c.LastCommittedSize() != 5 {
+		t.Errorf("LastCommittedSize: got %d want 5", c.LastCommittedSize())
+	}
+	if got := client.Calls(); got != 1 {
+		t.Errorf("client calls: got %d want 1", got)
+	}
+}
+
+func TestCommitOnce_SkipsWhenTreeUnchanged(t *testing.T) {
+	tree := &fakeTree{size: 5, root: newRoot(0xab)}
+	client := NewFakeEVMClient()
+	c, _ := newCommitter(t, tree, client)
+
+	if _, _, err := c.CommitOnce(context.Background()); err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+	// Second tick with same size — must not broadcast.
+	_, ok, err := c.CommitOnce(context.Background())
+	if !errors.Is(err, ErrTreeShrank) {
+		t.Errorf("expected ErrTreeShrank, got %v", err)
+	}
+	if ok {
+		t.Errorf("ok must be false on skip")
+	}
+	if got := client.Calls(); got != 1 {
+		t.Errorf("client calls: got %d want 1", got)
+	}
+}
+
+func TestCommitOnce_RejectsEmptyTree(t *testing.T) {
+	tree := &fakeTree{size: 0, root: newRoot(0)}
+	client := NewFakeEVMClient()
+	c, _ := newCommitter(t, tree, client)
+
+	_, ok, err := c.CommitOnce(context.Background())
+	if !errors.Is(err, ErrEmptyTree) {
+		t.Errorf("expected ErrEmptyTree, got %v", err)
+	}
+	if ok {
+		t.Errorf("ok must be false on empty")
+	}
+	if got := client.Calls(); got != 0 {
+		t.Errorf("client must not be called on empty tree, got %d", got)
+	}
+}
+
+func TestCommitOnce_PropagatesClientError(t *testing.T) {
+	tree := &fakeTree{size: 5, root: newRoot(0xab)}
+	client := NewFakeEVMClient()
+	want := errors.New("rpc down")
+	client.SetNextError(want)
+
+	c, store := newCommitter(t, tree, client)
+	_, ok, err := c.CommitOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrCommitFailed) {
+		t.Errorf("error should wrap ErrCommitFailed: %v", err)
+	}
+	if ok {
+		t.Error("ok must be false on rpc error")
+	}
+	if c.LastCommittedSize() != 0 {
+		t.Errorf("LastCommittedSize must stay at 0 on failure, got %d", c.LastCommittedSize())
+	}
+	if _, err := store.Latest(); !errors.Is(err, ErrNoAnchorYet) {
+		t.Errorf("store should be empty on failure, got %v", err)
+	}
+}
+
+func TestCommitOnce_GrowingTreeProducesNewAnchors(t *testing.T) {
+	tree := &fakeTree{size: 5, root: newRoot(0x01)}
+	client := NewFakeEVMClient()
+	c, store := newCommitter(t, tree, client)
+
+	if _, _, err := c.CommitOnce(context.Background()); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	tree.size = 9
+	tree.root = newRoot(0x02)
+	if _, _, err := c.CommitOnce(context.Background()); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if got := client.Calls(); got != 2 {
+		t.Errorf("expected 2 commits, got %d", got)
+	}
+	last, _ := store.Latest()
+	if last.TreeSize != 9 {
+		t.Errorf("latest size: got %d want 9", last.TreeSize)
+	}
+	if !bytes.Equal(last.Root, tree.root) {
+		t.Errorf("latest root mismatch")
+	}
+}
+
+func TestNewCommitter_RequiresDeps(t *testing.T) {
+	cases := []struct {
+		name   string
+		tree   TreeView
+		client EVMClient
+		store  *LatestStore
+	}{
+		{"no tree", nil, NewFakeEVMClient(), NewLatestStore()},
+		{"no client", &fakeTree{}, nil, NewLatestStore()},
+		{"no store", &fakeTree{}, NewFakeEVMClient(), nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewCommitter(tc.tree, tc.client, tc.store, CommitterOptions{}); err == nil {
+				t.Errorf("expected error")
+			}
+		})
+	}
+}
+
+func TestStartStopGracefully(t *testing.T) {
+	tree := &fakeTree{size: 1, root: newRoot(0xa)}
+	client := NewFakeEVMClient()
+	store := NewLatestStore()
+	c, err := NewCommitter(tree, client, store, CommitterOptions{
+		Interval: 5 * time.Millisecond,
+		Clock:    func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+		Logger:   slog.New(slog.NewTextHandler(new(bytes.Buffer), nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewCommitter: %v", err)
+	}
+	c.Start(context.Background())
+	// Give the loop a couple of ticks to do its first commit.
+	time.Sleep(20 * time.Millisecond)
+	if !c.Stop(time.Second) {
+		t.Fatal("Stop did not exit cleanly")
+	}
+	if c.LastCommittedSize() == 0 {
+		t.Errorf("expected at least one commit")
+	}
+}

--- a/go-key-service/internal/anchor/committer_test.go
+++ b/go-key-service/internal/anchor/committer_test.go
@@ -17,8 +17,7 @@ type fakeTree struct {
 	root []byte
 }
 
-func (f *fakeTree) Size() uint64 { return f.size }
-func (f *fakeTree) Root() []byte  { return f.root }
+func (f *fakeTree) Snapshot() (uint64, []byte) { return f.size, f.root }
 
 func newRoot(b byte) []byte {
 	out := make([]byte, HashSize)
@@ -154,7 +153,10 @@ func TestCommitOnce_GrowingTreeProducesNewAnchors(t *testing.T) {
 	if got := client.Calls(); got != 2 {
 		t.Errorf("expected 2 commits, got %d", got)
 	}
-	last, _ := store.Latest()
+	last, err := store.Latest()
+	if err != nil {
+		t.Fatalf("store.Latest: %v", err)
+	}
 	if last.TreeSize != 9 {
 		t.Errorf("latest size: got %d want 9", last.TreeSize)
 	}

--- a/go-key-service/internal/anchor/http/handler.go
+++ b/go-key-service/internal/anchor/http/handler.go
@@ -1,0 +1,76 @@
+// Package anchorhttp exposes the on-chain anchor indexer over JSON HTTP.
+package anchorhttp
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/anchor"
+)
+
+// Mount attaches the anchor endpoints onto an existing chi.Router.
+func Mount(r chi.Router, store *anchor.LatestStore, logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	h := &handler{store: store, logger: logger}
+	r.Route("/v1/anchor", func(r chi.Router) {
+		r.Get("/latest", h.latest)
+	})
+}
+
+// Handler returns a standalone http.Handler — useful for tests.
+func Handler(store *anchor.LatestStore, logger *slog.Logger) http.Handler {
+	r := chi.NewRouter()
+	Mount(r, store, logger)
+	return r
+}
+
+type handler struct {
+	store  *anchor.LatestStore
+	logger *slog.Logger
+}
+
+type latestResponse struct {
+	ID          uint64 `json:"id"`
+	TreeSize    uint64 `json:"tree_size"`
+	RootHex     string `json:"root_hex"`
+	TimestampMs int64  `json:"timestamp_ms"`
+	BlockNumber uint64 `json:"block_number,omitempty"`
+	TxHash      string `json:"tx_hash,omitempty"`
+}
+
+func (h *handler) latest(w http.ResponseWriter, _ *http.Request) {
+	a, err := h.store.Latest()
+	if err != nil {
+		if errors.Is(err, anchor.ErrNoAnchorYet) {
+			writeError(w, http.StatusNotFound, "no_anchor_yet", err.Error())
+			return
+		}
+		h.logger.Error("anchor latest", "err", err)
+		writeError(w, http.StatusInternalServerError, "internal", "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, latestResponse{
+		ID:          a.ID,
+		TreeSize:    a.TreeSize,
+		RootHex:     "0x" + hex.EncodeToString(a.Root),
+		TimestampMs: a.Timestamp.UnixMilli(),
+		BlockNumber: a.BlockNumber,
+		TxHash:      a.TxHash,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, map[string]string{"error": code, "message": msg})
+}

--- a/go-key-service/internal/anchor/http/handler_test.go
+++ b/go-key-service/internal/anchor/http/handler_test.go
@@ -1,0 +1,73 @@
+package anchorhttp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/anchor"
+)
+
+func TestLatest_404WhenEmpty(t *testing.T) {
+	store := anchor.NewLatestStore()
+	srv := httptest.NewServer(Handler(store, nil))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/anchor/latest")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", resp.StatusCode)
+	}
+}
+
+func TestLatest_ReturnsLatestAnchor(t *testing.T) {
+	store := anchor.NewLatestStore()
+	root := make([]byte, anchor.HashSize)
+	for i := range root {
+		root[i] = 0xab
+	}
+	store.Set(anchor.Anchor{
+		ID:          7,
+		TreeSize:    42,
+		Root:        root,
+		Timestamp:   time.UnixMilli(1_700_000_000_500).UTC(),
+		BlockNumber: 12345,
+		TxHash:      "0xdeadbeef",
+	})
+
+	srv := httptest.NewServer(Handler(store, nil))
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/v1/anchor/latest")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["tree_size"].(float64) != 42 {
+		t.Errorf("tree_size: got %v want 42", body["tree_size"])
+	}
+	if body["root_hex"] != "0x"+strings.Repeat("ab", 32) {
+		t.Errorf("root_hex: got %v", body["root_hex"])
+	}
+	if body["block_number"].(float64) != 12345 {
+		t.Errorf("block_number: got %v", body["block_number"])
+	}
+	if body["tx_hash"] != "0xdeadbeef" {
+		t.Errorf("tx_hash: got %v", body["tx_hash"])
+	}
+	if body["timestamp_ms"].(float64) != 1_700_000_000_500 {
+		t.Errorf("timestamp_ms: got %v", body["timestamp_ms"])
+	}
+}

--- a/go-key-service/internal/config/config.go
+++ b/go-key-service/internal/config/config.go
@@ -9,6 +9,34 @@ import (
 	"time"
 )
 
+// Secret is a string that hides its contents in String() / MarshalJSON
+// outputs. Use it for fields that hold credentials so accidental log
+// lines or JSON dumps of Config don't leak the value.
+type Secret string
+
+// String redacts the secret. The raw value is retrieved with Reveal.
+func (s Secret) String() string {
+	if s == "" {
+		return ""
+	}
+	return "[REDACTED]"
+}
+
+// GoString redacts the secret in fmt's %#v form too.
+func (s Secret) GoString() string { return s.String() }
+
+// MarshalJSON redacts on JSON marshal.
+func (s Secret) MarshalJSON() ([]byte, error) {
+	if s == "" {
+		return []byte(`""`), nil
+	}
+	return []byte(`"[REDACTED]"`), nil
+}
+
+// Reveal returns the underlying value. Call only when handing the
+// secret to the consumer (e.g. the anchor client constructor).
+func (s Secret) Reveal() string { return string(s) }
+
 // AnchorMode controls the anchor committer wiring.
 type AnchorMode string
 
@@ -32,7 +60,7 @@ type Config struct {
 	AnchorInterval        time.Duration
 	AnchorContractAddress string
 	AnchorRPCURL          string
-	AnchorPrivateKey      string
+	AnchorPrivateKey      Secret
 	AnchorCastBinary      string
 }
 
@@ -66,7 +94,7 @@ func Load() (Config, error) {
 	case AnchorCast:
 		cfg.AnchorContractAddress = os.Getenv("ANCHOR_CONTRACT_ADDRESS")
 		cfg.AnchorRPCURL = os.Getenv("ANCHOR_RPC_URL")
-		cfg.AnchorPrivateKey = os.Getenv("ANCHOR_PRIVATE_KEY")
+		cfg.AnchorPrivateKey = Secret(os.Getenv("ANCHOR_PRIVATE_KEY"))
 		cfg.AnchorCastBinary = os.Getenv("ANCHOR_CAST_BINARY")
 		if cfg.AnchorContractAddress == "" || cfg.AnchorRPCURL == "" || cfg.AnchorPrivateKey == "" {
 			return Config{}, fmt.Errorf(

--- a/go-key-service/internal/config/config.go
+++ b/go-key-service/internal/config/config.go
@@ -6,17 +6,42 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
+)
+
+// AnchorMode controls the anchor committer wiring.
+type AnchorMode string
+
+const (
+	// AnchorOff disables on-chain anchoring entirely. Default.
+	AnchorOff AnchorMode = "off"
+	// AnchorDryRun runs the committer with the in-memory FakeEVMClient —
+	// the indexer endpoint returns real anchors, but no transaction is
+	// broadcast. Useful for the demo / dashboard wiring.
+	AnchorDryRun AnchorMode = "dry-run"
+	// AnchorCast runs the committer with the foundry `cast send` client.
+	// Requires ANCHOR_CONTRACT_ADDRESS, ANCHOR_RPC_URL, ANCHOR_PRIVATE_KEY.
+	AnchorCast AnchorMode = "cast"
 )
 
 type Config struct {
 	Addr     string
 	LogLevel slog.Level
+
+	AnchorMode            AnchorMode
+	AnchorInterval        time.Duration
+	AnchorContractAddress string
+	AnchorRPCURL          string
+	AnchorPrivateKey      string
+	AnchorCastBinary      string
 }
 
 func Load() (Config, error) {
 	cfg := Config{
-		Addr:     getEnv("KEYSERVER_ADDR", ":8080"),
-		LogLevel: slog.LevelInfo,
+		Addr:           getEnv("KEYSERVER_ADDR", ":8080"),
+		LogLevel:       slog.LevelInfo,
+		AnchorMode:     AnchorMode(strings.ToLower(getEnv("ANCHOR_MODE", string(AnchorOff)))),
+		AnchorInterval: 15 * time.Minute,
 	}
 	if raw := os.Getenv("KEYSERVER_LOG_LEVEL"); raw != "" {
 		lvl, err := parseLevel(raw)
@@ -24,6 +49,32 @@ func Load() (Config, error) {
 			return Config{}, err
 		}
 		cfg.LogLevel = lvl
+	}
+	if raw := os.Getenv("ANCHOR_INTERVAL"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return Config{}, fmt.Errorf("config: ANCHOR_INTERVAL: %w", err)
+		}
+		if d <= 0 {
+			return Config{}, fmt.Errorf("config: ANCHOR_INTERVAL must be > 0")
+		}
+		cfg.AnchorInterval = d
+	}
+	switch cfg.AnchorMode {
+	case AnchorOff, AnchorDryRun:
+		// nothing further to load
+	case AnchorCast:
+		cfg.AnchorContractAddress = os.Getenv("ANCHOR_CONTRACT_ADDRESS")
+		cfg.AnchorRPCURL = os.Getenv("ANCHOR_RPC_URL")
+		cfg.AnchorPrivateKey = os.Getenv("ANCHOR_PRIVATE_KEY")
+		cfg.AnchorCastBinary = os.Getenv("ANCHOR_CAST_BINARY")
+		if cfg.AnchorContractAddress == "" || cfg.AnchorRPCURL == "" || cfg.AnchorPrivateKey == "" {
+			return Config{}, fmt.Errorf(
+				"config: ANCHOR_MODE=cast requires ANCHOR_CONTRACT_ADDRESS, ANCHOR_RPC_URL, ANCHOR_PRIVATE_KEY",
+			)
+		}
+	default:
+		return Config{}, fmt.Errorf("config: unknown ANCHOR_MODE %q", cfg.AnchorMode)
 	}
 	return cfg, nil
 }

--- a/go-key-service/internal/config/config_test.go
+++ b/go-key-service/internal/config/config_test.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -100,5 +103,41 @@ func TestAnchorRejectsUnknownMode(t *testing.T) {
 	t.Setenv("ANCHOR_MODE", "lunar")
 	if _, err := Load(); err == nil {
 		t.Fatal("expected error on unknown anchor mode")
+	}
+}
+
+func TestSecretRedactsInString(t *testing.T) {
+	s := Secret("0xdeadbeef")
+	if got := s.String(); got == "0xdeadbeef" {
+		t.Errorf("String() leaked the secret: %q", got)
+	}
+	if got := fmt.Sprintf("%v", s); strings.Contains(got, "deadbeef") {
+		t.Errorf("%%v leaked the secret: %q", got)
+	}
+	if got := fmt.Sprintf("%#v", s); strings.Contains(got, "deadbeef") {
+		t.Errorf("%%#v leaked the secret: %q", got)
+	}
+	if Secret("").String() != "" {
+		t.Errorf("empty secret should stringify as empty")
+	}
+}
+
+func TestSecretRedactsInJSON(t *testing.T) {
+	type holder struct {
+		Key Secret `json:"key"`
+	}
+	out, err := json.Marshal(holder{Key: Secret("0xdeadbeef")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "deadbeef") {
+		t.Errorf("MarshalJSON leaked the secret: %s", out)
+	}
+}
+
+func TestSecretReveal(t *testing.T) {
+	s := Secret("0xdeadbeef")
+	if s.Reveal() != "0xdeadbeef" {
+		t.Errorf("Reveal() should return raw value")
 	}
 }

--- a/go-key-service/internal/config/config_test.go
+++ b/go-key-service/internal/config/config_test.go
@@ -41,3 +41,64 @@ func TestLoadInvalidLevel(t *testing.T) {
 		t.Fatal("expected error on invalid level")
 	}
 }
+
+func TestAnchorDefaultsOff(t *testing.T) {
+	t.Setenv("ANCHOR_MODE", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AnchorMode != AnchorOff {
+		t.Errorf("AnchorMode default: got %q want %q", cfg.AnchorMode, AnchorOff)
+	}
+}
+
+func TestAnchorDryRunNeedsNothing(t *testing.T) {
+	t.Setenv("ANCHOR_MODE", "dry-run")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AnchorMode != AnchorDryRun {
+		t.Errorf("AnchorMode: got %q want dry-run", cfg.AnchorMode)
+	}
+}
+
+func TestAnchorCastRequiresAllFields(t *testing.T) {
+	t.Setenv("ANCHOR_MODE", "cast")
+	t.Setenv("ANCHOR_CONTRACT_ADDRESS", "")
+	t.Setenv("ANCHOR_RPC_URL", "")
+	t.Setenv("ANCHOR_PRIVATE_KEY", "")
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error on missing cast fields")
+	}
+	t.Setenv("ANCHOR_CONTRACT_ADDRESS", "0xabc")
+	t.Setenv("ANCHOR_RPC_URL", "http://localhost:8545")
+	t.Setenv("ANCHOR_PRIVATE_KEY", "0xdead")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected success with all fields, got %v", err)
+	}
+	if cfg.AnchorContractAddress != "0xabc" {
+		t.Errorf("contract address not loaded")
+	}
+}
+
+func TestAnchorIntervalParsed(t *testing.T) {
+	t.Setenv("ANCHOR_MODE", "dry-run")
+	t.Setenv("ANCHOR_INTERVAL", "30s")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AnchorInterval.String() != "30s" {
+		t.Errorf("AnchorInterval: got %v want 30s", cfg.AnchorInterval)
+	}
+}
+
+func TestAnchorRejectsUnknownMode(t *testing.T) {
+	t.Setenv("ANCHOR_MODE", "lunar")
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error on unknown anchor mode")
+	}
+}

--- a/go-key-service/internal/httpapi/handlers.go
+++ b/go-key-service/internal/httpapi/handlers.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/anchor"
+	anchorhttp "github.com/knhn1004/CryptoAgent/go-key-service/internal/anchor/http"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
 	auditloghttp "github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog/http"
 	"github.com/knhn1004/CryptoAgent/go-key-service/internal/capability"
@@ -19,10 +21,11 @@ import (
 )
 
 type Server struct {
-	store      keystore.KeyStore
-	pipeline   *auditlog.Pipeline
-	capability *capability.Service
-	logger     *slog.Logger
+	store       keystore.KeyStore
+	pipeline    *auditlog.Pipeline
+	capability  *capability.Service
+	anchorStore *anchor.LatestStore
+	logger      *slog.Logger
 }
 
 func NewServer(store keystore.KeyStore, logger *slog.Logger) *Server {
@@ -47,6 +50,13 @@ func (s *Server) WithCapability(c *capability.Service) *Server {
 	return s
 }
 
+// WithAnchor mounts the on-chain anchor indexer endpoints. Optional; the
+// keyserver runs fine without it for setups that don't anchor on-chain.
+func (s *Server) WithAnchor(latest *anchor.LatestStore) *Server {
+	s.anchorStore = latest
+	return s
+}
+
 func (s *Server) Router() http.Handler {
 	r := chi.NewRouter()
 	r.Use(s.logRequests)
@@ -64,6 +74,9 @@ func (s *Server) Router() http.Handler {
 	}
 	if s.capability != nil {
 		capabilityhttp.Mount(r, s.capability, s.logger)
+	}
+	if s.anchorStore != nil {
+		anchorhttp.Mount(r, s.anchorStore, s.logger)
 	}
 	return r
 }

--- a/go-key-service/internal/merkle/tree.go
+++ b/go-key-service/internal/merkle/tree.go
@@ -95,6 +95,15 @@ func (t *Tree) Root() []byte {
 	return mth(t.leaves)
 }
 
+// Snapshot returns the current `(size, root)` pair under a single
+// read lock, so callers (notably the on-chain anchor committer) get a
+// consistent view even when appends are happening concurrently.
+func (t *Tree) Snapshot() (uint64, []byte) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return uint64(len(t.leaves)), mth(t.leaves)
+}
+
 // RootAt returns the root of the tree's first `size` leaves.
 func (t *Tree) RootAt(size uint64) ([]byte, error) {
 	t.mu.RLock()


### PR DESCRIPTION
## Summary

- **Solidity:** `AuditAnchor.sol` (Foundry). Single trusted committer posts `(treeSize, root, timestamp)`; the contract enforces strict monotonicity (`TreeShrank`), rejects empty trees, and emits `AuditAnchored(id, treeSize, root, blockNumber, timestamp)`. Owner/committer roles are split; ownership handover is two-step.
- **Go committer:** `internal/anchor/` — a `TreeView -> EVMClient -> LatestStore` pipeline. The `Committer` goroutine polls every `ANCHOR_INTERVAL` (default `15m`) and only broadcasts when the tree has grown.
- **Two EVMClient impls:** `FakeEVMClient` (in-memory, used by `ANCHOR_MODE=dry-run` and the unit tests) and `CastClient` which shells out to foundry's `cast send` — keeps `go-ethereum` out of `go.mod`.
- **Indexer:** `GET /v1/anchor/latest` returns the most recent committed anchor as JSON. Mounted on the keyserver behind `ANCHOR_MODE`.

Closes #13.

## Acceptance checklist

- [x] Contract emits `AuditAnchored(root, blockNumber)` (we also emit `id`, `treeSize`, `timestamp` for richer indexing).
- [x] Worker submits `(root, timestamp, agent_signatures)` on schedule. *Note*: agent signatures are already in the off-chain Merkle leaf (`canonical(action) || sig`); the on-chain commit stays intentionally minimal — `(treeSize, root, ts)` plus the committer's tx signature — and the leaf signatures are recoverable from the audit log via the indexed root.
- [ ] Deployed to a public testnet (Sepolia); address recorded in repo. *Not done in this PR* — the deploy script is wired (`script/DeployAuditAnchor.s.sol`) but actually broadcasting needs a funded Sepolia key. Filed as follow-up.
- [x] Indexer reads back the most recent anchor and exposes it via API (`GET /v1/anchor/latest`).

## Test plan

- [x] `forge test -vv` (in `contracts/`) — 14/14 passed
- [x] `go test ./...` (in `go-key-service/`) — all packages green, including `internal/anchor`, `internal/anchor/http`, `internal/config`
- [x] `go build ./...`
- [x] `go vet ./...`

## Notes for reviewers

- **Why \`cast send\` instead of go-ethereum.** Foundry is already a hard dep for the contract side (`forge build`/`forge test` in CI). Reusing its `cast` binary for broadcast keeps Go's transitive dep set unchanged — no secp256k1 cgo, no \~30 transitive packages. The `EVMClient` interface in `client.go` means we can swap to a go-ethereum-backed impl later without touching the committer.
- **Monotonicity is enforced twice.** `Committer.commit` short-circuits when `treeSize <= lastCommitted` (saves a doomed RPC), and the contract reverts with `TreeShrank` if the off-chain check ever drifts. The `FakeEVMClient` mirrors the same revert in-memory so unit tests catch the bug locally.
- **Dry-run mode.** `ANCHOR_MODE=dry-run` is the demo path: it spins up the full committer goroutine and the `/v1/anchor/latest` endpoint with the `FakeEVMClient`. The dashboard can render real anchor records without the deploy step.
- **Submodule.** `lib/forge-std` is added as a git submodule (the standard Foundry pattern). CI's `actions/checkout@v4 with: submodules: recursive` already picks it up; the existing `.github/workflows/contracts.yml` runs `forge build --sizes` and `forge test -vvv` end-to-end.
- **Threat-model fit.** This is the realisation of T8 in `docs/threat_model.md` — periodic on-chain commits give an external observer (anyone with an Sepolia archive node) the ability to re-run RFC 6962 consistency proofs against any committed root, which is what makes a compromised log host detectable rather than just "wrong."