### PR TITLE
test(e2e): success-metric suite for all four proposal metrics (#20)

### DIFF
--- a/go-key-service/internal/e2e/e2e_test.go
+++ b/go-key-service/internal/e2e/e2e_test.go
@@ -1,0 +1,232 @@
+// Package e2e wires together the audit pipeline, the keystore, and
+// the Merkle tree the way `cmd/keyserver` does, then drives them
+// through every adversarial scenario the project proposal calls
+// out as a success metric.
+//
+// The suite is the home for two of the four metrics from
+// docs/proposal:
+//
+//   - 100% of agent messages signed and verified end-to-end.
+//   - Tampering past a leaf produces a detectable root mismatch
+//     against any historical anchor (RFC 6962 consistency).
+//
+// The other two metrics (multi-sig bypass count, ACL rejection
+// count) live in the SDK side at sdk-python/tests/test_e2e_success_metrics.py
+// because they're orchestrator-level checks that exercise decorators
+// the agent code calls into.
+package e2e
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/action"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/auditlog"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/keystore"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/merkle"
+	"github.com/knhn1004/CryptoAgent/go-key-service/internal/signing"
+)
+
+// fixedClock returns a clock function pinned at ts so timestamp skew
+// checks pass deterministically.
+func fixedClock(ts time.Time) func() time.Time { return func() time.Time { return ts } }
+
+// makeAction builds a canonical Action whose timestamp is exactly
+// `nowMs`, so the pipeline's skew check is happy when the pipeline
+// clock is also pinned to nowMs.
+func makeAction(agentID, actionType, target, nonce string, nowMs int64) *action.Action {
+	return &action.Action{
+		SchemaVersion: action.SchemaVersion,
+		AgentID:       agentID,
+		ActionType:    actionType,
+		Target:        target,
+		TimestampMs:   nowMs,
+		Nonce:         nonce,
+	}
+}
+
+// nonces yields N distinct 32-char lowercase hex nonces.
+func nonces(n int) []string {
+	out := make([]string, n)
+	const hex = "0123456789abcdef"
+	for i := 0; i < n; i++ {
+		var buf [32]byte
+		v := uint64(i + 1)
+		for j := 31; j >= 0; j-- {
+			buf[j] = hex[v&0xF]
+			v >>= 4
+		}
+		out[i] = string(buf[:])
+	}
+	return out
+}
+
+// Metric 1 — every signed action submitted to the pipeline is
+// verified and lands in the Merkle log; every forged signature is
+// rejected. The success criterion is "100% of accepted actions are
+// verified", which we assert as: tree size == accepted == verified
+// submissions, and forged submissions never grow the tree.
+func TestE2E_AllSignedActionsAreVerified(t *testing.T) {
+	const honestN = 50
+	const forgedN = 10
+	ts := time.UnixMilli(1_700_000_000_000).UTC()
+
+	store := keystore.NewMemory()
+	tree := merkle.New()
+	pipe := auditlog.New(tree, store, auditlog.WithClock(fixedClock(ts)))
+
+	ctx := context.Background()
+	if _, err := store.Create(ctx, "alice"); err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	_, alicePriv, err := store.Get(ctx, "alice")
+	if err != nil {
+		t.Fatalf("get alice: %v", err)
+	}
+
+	// Plant a separate keypair we'll use to forge signatures over the
+	// same canonical bytes — they must never verify against alice's pubkey.
+	_, attackerPriv, err := signing.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("attacker key: %v", err)
+	}
+
+	ns := nonces(honestN + forgedN)
+
+	accepted := 0
+	for i := 0; i < honestN; i++ {
+		a := makeAction("alice", "transfer_funds", "vault/treasury", ns[i], ts.UnixMilli())
+		sig, err := signing.Sign(a, alicePriv)
+		if err != nil {
+			t.Fatalf("sign honest %d: %v", i, err)
+		}
+		ev, isNew, err := pipe.Submit(ctx, a, sig)
+		if err != nil {
+			t.Fatalf("submit honest %d: %v", i, err)
+		}
+		if !isNew || ev == nil {
+			t.Fatalf("honest %d: expected fresh append", i)
+		}
+		accepted++
+	}
+
+	// Forged: same agent_id but signed with a different private key.
+	rejected := 0
+	for i := 0; i < forgedN; i++ {
+		a := makeAction("alice", "transfer_funds", "vault/treasury", ns[honestN+i], ts.UnixMilli())
+		sig, err := signing.Sign(a, attackerPriv)
+		if err != nil {
+			t.Fatalf("sign forged %d: %v", i, err)
+		}
+		_, _, err = pipe.Submit(ctx, a, sig)
+		if !errors.Is(err, signing.ErrInvalidSignature) {
+			t.Fatalf("forged %d: want ErrInvalidSignature, got %v", i, err)
+		}
+		rejected++
+	}
+
+	gotSize := pipe.Size()
+	if gotSize != uint64(accepted) {
+		t.Fatalf("audit-log size mismatch: tree=%d accepted=%d", gotSize, accepted)
+	}
+	if uint64(tree.Size()) != gotSize {
+		t.Fatalf("tree/pipeline size mismatch: tree=%d pipe=%d", tree.Size(), gotSize)
+	}
+	if rejected != forgedN {
+		t.Fatalf("forged-rejection count mismatch: got %d want %d", rejected, forgedN)
+	}
+
+	// 100% verified-rate over the appended set: every event in the log
+	// has a signature that re-verifies against the store-held pubkey.
+	pub, _, err := store.Get(ctx, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := pipe.EventsSince(0)
+	if len(events) != accepted {
+		t.Fatalf("EventsSince mismatch: got %d want %d", len(events), accepted)
+	}
+	for i, ev := range events {
+		if err := signing.Verify(ev.Action, ev.Signature, pub); err != nil {
+			t.Fatalf("event %d failed re-verify: %v", i, err)
+		}
+		// Replay protection on the same nonce must not allow a second append.
+		_, isNew, err := pipe.Submit(ctx, ev.Action, ev.Signature)
+		if err != nil {
+			t.Fatalf("replay submit %d: %v", i, err)
+		}
+		if isNew {
+			t.Fatalf("event %d: replay grew the tree (replay protection broken)", i)
+		}
+	}
+
+	t.Logf("metric 1: signed+verified=%d/%d (100%%); forged rejections=%d", accepted, accepted, rejected)
+}
+
+// Metric 3 — tampering past a historical leaf is detected by the
+// consistency verifier with a hex-bearing diagnostic. Covers the
+// adversarial scenario from docs/threat_model.md T7: a compromised
+// log operator presents a *rewritten* live tree that disagrees with
+// an externally-anchored historical root.
+//
+// We model the rewrite by building two trees: the honest one supplies
+// the historical root snapshot; the adversarial one is what the
+// verifier sees. The verifier MUST refuse with a non-empty diagnostic
+// message and either ErrRootMismatch or ErrInvalidProof.
+func TestE2E_TamperedLeafIsDetected(t *testing.T) {
+	const historicalSize = uint64(8)
+	const liveSize = uint64(16)
+
+	honest := merkle.New()
+	for i := 0; i < int(liveSize); i++ {
+		if _, err := honest.Append([]byte{byte(i)}); err != nil {
+			t.Fatalf("honest append %d: %v", i, err)
+		}
+	}
+	historicalRoot, err := honest.RootAt(historicalSize)
+	if err != nil {
+		t.Fatalf("RootAt: %v", err)
+	}
+
+	// Sanity: verifying the snapshot against the *honest* live tree must succeed.
+	if rep, err := merkle.NewVerifier(honest).VerifyHistoricalRoot(historicalRoot, historicalSize); err != nil || !rep.OK {
+		t.Fatalf("honest verifier must accept snapshot: err=%v report=%+v", err, rep)
+	}
+
+	// Adversary publishes a tree where leaf 3 has been swapped for
+	// different content. Same RFC 6962 leaf hashing, well-formed
+	// structure — the only thing wrong is that one byte changed.
+	adversary := merkle.New()
+	for i := 0; i < int(liveSize); i++ {
+		payload := []byte{byte(i)}
+		if i == 3 {
+			payload = []byte{0xFF}
+		}
+		if _, err := adversary.Append(payload); err != nil {
+			t.Fatalf("adversary append %d: %v", i, err)
+		}
+	}
+
+	report, err := merkle.NewVerifier(adversary).VerifyHistoricalRoot(historicalRoot, historicalSize)
+	if err == nil {
+		t.Fatal("verifier must reject rewritten tree, got nil error")
+	}
+	if !errors.Is(err, merkle.ErrRootMismatch) && !errors.Is(err, merkle.ErrInvalidProof) {
+		t.Fatalf("expected ErrRootMismatch or ErrInvalidProof, got %v", err)
+	}
+	if report == nil {
+		t.Fatal("report should be non-nil even on failure")
+	}
+	if report.OK {
+		t.Fatalf("report.OK must be false, got %+v", report)
+	}
+	if report.HistoricalRoot == "" || report.LiveRoot == "" || report.HistoricalRoot == report.LiveRoot {
+		t.Fatalf("diagnostic must surface distinct hex roots, got %+v", report)
+	}
+	if report.Message == "" {
+		t.Fatal("report.Message must be non-empty for the dashboard to display")
+	}
+	t.Logf("metric 3: tamper detected: %s historical=%s live=%s", report.Message, report.HistoricalRoot, report.LiveRoot)
+}

--- a/sdk-python/tests/test_e2e_success_metrics.py
+++ b/sdk-python/tests/test_e2e_success_metrics.py
@@ -1,0 +1,229 @@
+"""End-to-end success-metric tests for the orchestrator side.
+
+The proposal lists four numeric success metrics. This file covers the
+two that live on the SDK side; the other two (signature verification
+rate, tamper detection) are exercised in
+``go-key-service/internal/e2e``.
+
+Metrics covered here:
+
+* **Multi-sig bypass count** — a critical action wrapped in ``@gated``
+  must increment ``Gate.bypass_count`` when a caller skips
+  ``Gate.execute``. This is the success-metric input for "how often
+  did the trust layer block an end-run around the multi-sig gate?".
+* **Out-of-scope action rejection count** — a call wrapped in
+  ``@requires_token`` whose token does not cover
+  ``(action_type, target)`` must be rejected by the Go service's
+  ``/v1/tokens/verify`` endpoint, and the orchestrator's
+  ``UnauthorizedMetrics`` must record one increment per rejection.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cryptoagent import (
+    BypassError,
+    Gate,
+    Token,
+    TokenClient,
+    TokenError,
+    UnauthorizedMetrics,
+    gated,
+    generate_keypair,
+    requires_token,
+    sign,
+    signed_action,
+    token_context,
+)
+from cryptoagent.action import Action
+from tests.conftest import _issue_response
+
+# ---------------------------------------------------------------------------
+# Metric 2 — multi-sig bypass count
+# ---------------------------------------------------------------------------
+
+
+def _critical_action(*, agent_id: str = "alice", target: str = "vault/treasury") -> Action:
+    return Action(
+        schema_version=1,
+        agent_id=agent_id,
+        action_type="transfer_funds",
+        target=target,
+        timestamp_ms=1_700_000_000_000,
+        nonce="0123456789abcdef0123456789abcdef",
+    )
+
+
+def test_metric_bypass_attempt_is_rejected_and_counted():
+    gate = Gate({"transfer_funds": 2})
+
+    @gated(gate, "transfer_funds")
+    def transfer(amount: int) -> str:
+        return f"moved {amount}"
+
+    # Direct invocation outside Gate.execute is the bypass scenario.
+    with pytest.raises(BypassError):
+        transfer(10)
+
+    # And one rejection records exactly one increment, attributed to
+    # the action_type the dashboard groups by.
+    assert gate.bypass_count("transfer_funds") == 1
+    assert gate.bypass_count() == 1
+    assert gate.bypass_metrics() == {"transfer_funds": 1}
+
+
+def test_metric_bypass_only_counts_actual_bypass_not_normal_use():
+    # Build a 2-of-2 quorum: two valid signers must both sign.
+    a_pub, a_priv = generate_keypair()
+    b_pub, b_priv = generate_keypair()
+    gate = Gate({"transfer_funds": 2})
+
+    @gated(gate, "transfer_funds")
+    def transfer(amount: int) -> str:
+        return f"moved {amount}"
+
+    a = _critical_action()
+    sig_a = sign(a, a_priv)
+    sig_b = sign(a, b_priv)
+
+    # Going through Gate.execute is the legitimate path. No increment.
+    out = gate.execute(a, [(a_pub, sig_a), (b_pub, sig_b)], transfer, 10)
+    assert out == "moved 10"
+    assert gate.bypass_count() == 0
+
+    # Now the adversary calls the wrapped function directly.
+    with pytest.raises(BypassError):
+        transfer(10)
+    assert gate.bypass_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Metric 4 — out-of-scope action ACL rejection count
+# ---------------------------------------------------------------------------
+
+
+def _build_decorated(
+    client: TokenClient, metrics: UnauthorizedMetrics, *, target: str = "vault/treasury"
+):
+    """Returns a callable that runs through @signed_action +
+    @requires_token, sharing the same UnauthorizedMetrics so callers
+    can assert the post-rejection count."""
+    _, priv = generate_keypair()
+
+    @signed_action(
+        agent_id="alice",
+        action_type="transfer_funds",
+        target=target,
+        private_key=priv,
+        clock=lambda: 1_700_000_000_000,
+    )
+    @requires_token(
+        client,
+        action_type="transfer_funds",
+        target=target,
+        metrics=metrics,
+    )
+    def call() -> str:
+        return "ok"
+
+    return call
+
+
+def test_metric_out_of_scope_action_is_rejected_and_counted(fake_service):
+    svc, base = fake_service
+    # The Go service rejects with one of the documented sentinels;
+    # the dashboard groups by the orchestrator's action_type label, so
+    # which sentinel doesn't matter for the metric.
+    svc.queue(403, {"error": "action_type_not_allowed", "message": "scope mismatch"})
+
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _build_decorated(client, metrics)
+
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError):
+            call()
+
+    assert metrics.count("transfer_funds") == 1
+    assert metrics.count() == 1
+    assert metrics.snapshot() == {"transfer_funds": 1}
+
+
+def test_metric_out_of_scope_target_is_rejected_and_counted(fake_service):
+    svc, base = fake_service
+    svc.queue(403, {"error": "target_not_allowed", "message": "scope mismatch"})
+
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _build_decorated(client, metrics, target="vault/payroll")
+
+    with token_context(Token.from_response(_issue_response())):
+        with pytest.raises(TokenError):
+            call()
+
+    assert metrics.count("transfer_funds") == 1
+
+
+def test_metric_in_scope_call_does_not_increment(fake_service):
+    svc, base = fake_service
+    svc.queue(200, {"ok": True, "token_id": "tok-1"})
+
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _build_decorated(client, metrics)
+
+    with token_context(Token.from_response(_issue_response())):
+        assert call() == "ok"
+    # Honest path must leave the counter at zero so the dashboard's
+    # unauthorized-rate isn't poisoned by every successful call.
+    assert metrics.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Composite roll-up — emits the same shape the dashboard would render.
+# ---------------------------------------------------------------------------
+
+
+def test_metric_rollup_emits_dashboard_payload(fake_service):
+    """Drive a small mixed workload and assert the per-metric counters
+    line up with what the dashboard expects to display.
+    """
+    svc, base = fake_service
+    # 3 honest + 2 ACL rejections + 1 bypass attempt.
+    for _ in range(3):
+        svc.queue(200, {"ok": True, "token_id": "tok-1"})
+    for _ in range(2):
+        svc.queue(403, {"error": "action_type_not_allowed", "message": "scope"})
+
+    client = TokenClient(base)
+    metrics = UnauthorizedMetrics()
+    call = _build_decorated(client, metrics)
+    gate = Gate({"transfer_funds": 1})
+
+    @gated(gate, "transfer_funds")
+    def transfer(amount: int) -> str:
+        return f"moved {amount}"
+
+    with token_context(Token.from_response(_issue_response())):
+        for _ in range(3):
+            assert call() == "ok"
+        for _ in range(2):
+            with pytest.raises(TokenError):
+                call()
+
+    with pytest.raises(BypassError):
+        transfer(10)
+
+    rollup = {
+        "unauthorized_total": metrics.count(),
+        "unauthorized_per_action": metrics.snapshot(),
+        "bypass_total": gate.bypass_count(),
+        "bypass_per_action": gate.bypass_metrics(),
+    }
+    assert rollup == {
+        "unauthorized_total": 2,
+        "unauthorized_per_action": {"transfer_funds": 2},
+        "bypass_total": 1,
+        "bypass_per_action": {"transfer_funds": 1},
+    }


### PR DESCRIPTION
## Summary

End-to-end suite that wires every component together and asserts each of the four numeric success metrics from the proposal. No new production code — pure assertions on existing trust-layer plumbing.

- **Go side** (\`internal/e2e/e2e_test.go\`): metrics 1 & 3 — verified-message rate, tamper detection.
- **Python side** (\`sdk-python/tests/test_e2e_success_metrics.py\`): metrics 2 & 4 — multi-sig bypass count, out-of-scope ACL rejection count, plus a composite roll-up that emits the dashboard payload.

Closes #20.

## Acceptance checklist

- [x] **100% of agent messages signed + verified.** Fifty honest signatures land in the audit log; ten forged signatures (signed with a different key but submitted under alice's agent_id) all bounce with \`ErrInvalidSignature\`; tree size equals accepted count; replay attempts on accepted events do not grow the log.
- [x] **Multi-sig bypass attempt → rejected + counted.** Direct call to a \`@gated\` function raises \`BypassError\` and bumps \`Gate.bypass_metrics\`; the honest \`Gate.execute\` path leaves the counter at zero.
- [x] **Tampering past leaf → root hash mismatch detected.** Adversary publishes a tree with one swapped leaf; the consistency verifier rejects with \`ErrRootMismatch\` and surfaces both roots in hex (the dashboard diagnostic). Models \`docs/threat_model.md\` T7.
- [x] **Out-of-scope action → ACL rejection counted.** \`@requires_token\` wired with \`UnauthorizedMetrics\` records one increment per server-side 403 (\`action_type_not_allowed\`, \`target_not_allowed\`); honest 200 path leaves the counter at zero.
- [x] **Run in CI on every PR.** Both go.yml and python.yml already pick up the new files via their existing path globs — no workflow changes.

## Test plan

- [x] \`go test ./internal/e2e/... -v\` (in \`go-key-service/\`) — both metric tests pass with hex-bearing diagnostics in the test log.
- [x] \`pytest tests/test_e2e_success_metrics.py -v\` (in \`sdk-python/\`) — 6/6 passed.
- [x] Full \`go test ./...\` and \`pytest -q\` still green (101 passed, 1 skipped on Python; all packages OK on Go).
- [x] \`ruff check\` + \`ruff format --check\` clean.

## Notes for reviewers

- **Why split across two languages.** The first two metrics (verified-message rate, tamper detection) live entirely in the Go service — the SDK never sees forged signatures or rewritten roots. The other two (bypass, ACL) are orchestrator-level checks that fire from decorators the agent code calls into. Splitting along the language boundary keeps each side small and testable without spawning the other process.
- **Tamper test models the rewrite, not in-place mutation.** The honest tree supplies the historical root; a separately-built adversarial tree is what the verifier sees. That's both a cleaner test (no reach-into-private-fields) and a more accurate adversary model — a compromised log operator publishes a *different* tree, they don't surgically edit the honest one.
- **Composite roll-up.** \`test_metric_rollup_emits_dashboard_payload\` runs 3 honest + 2 ACL rejections + 1 bypass and asserts the resulting four-counter dict matches exactly. Cross-metric isolation: a bypass attempt does not bump unauthorized-rate, and vice versa.
- **Forged signatures are cross-keypair, not invalid bytes.** I used a freshly-generated attacker key over the same canonical bytes so the rejection path exercises the full ed25519.Verify failure rather than a length / format check. The failing path is more representative of a real adversary.